### PR TITLE
Bugfix for Deadlock on WS Connection Close

### DIFF
--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -102,6 +102,9 @@ func (s *WebsocketSuite) TestConnectionInvalid() {
 	result := s.sut.writeMessage(websocket.BinaryMessage, []byte{})
 	assert.Equal(s.T(), false, result)
 
+	err = s.sut.writeMessageWithoutErrorHandling(websocket.BinaryMessage, []byte{})
+	assert.NotNil(s.T(), err)
+
 	s.sut.conn = nil
 
 	data, err := s.sut.readWebsocketMessage()


### PR DESCRIPTION
Probably not the prettiest solution for the problem but this resolves #11.

After thorough manual tests, the deadlock could not be reproduced after applying this fix.