### PR TITLE
Fix certificate SKI calculation to use public instead of private key

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -33,14 +33,14 @@ func CreateCertificate(organizationalUnit, organization, country, commonName str
 		return tls.Certificate{}, err
 	}
 
-	// Create the EEBUS service SKI using the private key
-	asn1, err := x509.MarshalECPrivateKey(privateKey)
+	// Create the EEBUS service SKI using the public key
+	publicKey, err := privateKey.PublicKey.ECDH()
 	if err != nil {
 		return tls.Certificate{}, err
 	}
 	// SHIP 12.2: Required to be created according to RFC 3280 4.2.1.2
 	// #nosec G401
-	ski := sha1.Sum(asn1)
+	ski := sha1.Sum(publicKey.Bytes())
 
 	subject := pkix.Name{
 		OrganizationalUnit: []string{organizationalUnit},

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -59,14 +59,14 @@ func createInvalidCertificate(organizationalUnit, organization, country, commonN
 		return tls.Certificate{}, err
 	}
 
-	// Create the EEBUS service SKI using the private key
-	asn1, err := x509.MarshalECPrivateKey(privateKey)
+	// Create the EEBUS service SKI using the public key
+	publicKey, err := privateKey.PublicKey.ECDH()
 	if err != nil {
 		return tls.Certificate{}, err
 	}
 	// SHIP 12.2: Required to be created according to RFC 3280 4.2.1.2
 	// #nosec G401
-	ski := sha1.Sum(asn1)
+	ski := sha1.Sum(publicKey.Bytes())
 
 	subject := pkix.Name{
 		OrganizationalUnit: []string{organizationalUnit},


### PR DESCRIPTION
According to SHIP 12.2, the SKI SHALL be generated according to RFC 3280 4.2.1.2, method (1) which calculates the sha1 hash of the public key whereas the code previously calculated the sha1 hash of the private key.

The go stdlib [1](https://github.com/golang/go/blob/196b104bc172c8ba7e0565293722de319071ade3/src/crypto/x509/x509.go#L2180-L2187) [2](https://github.com/golang/go/blob/196b104bc172c8ba7e0565293722de319071ade3/src/crypto/x509/x509.go#L2159) [3](https://github.com/golang/go/blob/196b104bc172c8ba7e0565293722de319071ade3/src/crypto/x509/x509.go#L88C29-L88C30) uses [elliptic.Marshal](https://pkg.go.dev/crypto/elliptic@go1.22.4#Marshal), but we use [ECDH()](https://pkg.go.dev/crypto/ecdsa#PrivateKey.ECDH).[Bytes()](https://pkg.go.dev/crypto/ecdh@go1.22.4#PrivateKey.Bytes) instead as elliptic.Marshal is marked as deprecated in favor of ECDH().Bytes()

The calculation of the SKI can be tested/evaluated using the openssl toolchain as follows:
```
$ openssl x509 -noout -in cert.crt -pubkey | openssl asn1parse
    0:d=0  hl=2 l=  89 cons: SEQUENCE
    2:d=1  hl=2 l=  19 cons: SEQUENCE
    4:d=2  hl=2 l=   7 prim: OBJECT            :id-ecPublicKey
   13:d=2  hl=2 l=   8 prim: OBJECT            :prime256v1
   23:d=1  hl=2 l=  66 prim: BIT STRING
$ openssl x509 -noout -in cert.crt -pubkey | openssl asn1parse -strparse 23 -out public.der
Error in encoding
139986667922752:error:0D07209B:asn1 encoding routines:ASN1_get_object:too long:../crypto/asn1/asn1_lib.c:91:
$ openssl dgst -c -sha1 public.der
SHA1(public.der)= 21:02:2a:5b:07:ab:f8:80:8c:43:73:8d:c1:44:48:a6:e1:cb:e4:e0```