### PR TITLE
Fix possible panic

### DIFF
--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -397,6 +397,10 @@ func (m *MdnsManager) processMdnsEntry(elements map[string]string, name, host st
 }
 
 func (m *MdnsManager) RequestMdnsEntries() {
+	if m.report == nil {
+		return
+	}
+
 	entries := m.copyMdnsEntries()
 	go m.report.ReportMdnsEntries(entries)
 }


### PR DESCRIPTION
This panic may occur, if mDNS announcement failed and thus SHIP won’t be usable.