### PR TITLE
Improve reconnect attempts

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -160,5 +160,9 @@ func (h *Hub) checkAutoReannounce() {
 
 	if countPairedServices > countConnections {
 		_ = h.mdns.AnnounceMdnsEntry()
+
+		// also check currently known mDNS entries to see if they
+		// already contain the not connected remote service
+		h.mdns.RequestMdnsEntries()
 	}
 }


### PR DESCRIPTION
If a remote device closed the connection, e.g. trust not approved or websocket i/o error, then the reconnection attempt did only happen when the mDNS entry of the remote service was republished.

To fix this, automatically use the already known mDNS entries for a reconnect attempt.