### PR TITLE
Support implementations that send invalid trailing 0x00 bytes in JSON messages

### DIFF
--- a/ship/helper.go
+++ b/ship/helper.go
@@ -14,6 +14,7 @@ func JsonFromEEBUSJson(json []byte) []byte {
 	result = bytes.ReplaceAll(result, []byte("},{"), []byte(","))
 	result = bytes.ReplaceAll(result, []byte("}]"), []byte("}"))
 	result = bytes.ReplaceAll(result, []byte("[]"), []byte("{}"))
+	// The PMCP device mistakenly adds an `0x00` byte at the end of many messages.
 	result = bytes.Trim(result, "\x00")
 	return result
 }

--- a/ship/helper.go
+++ b/ship/helper.go
@@ -14,7 +14,7 @@ func JsonFromEEBUSJson(json []byte) []byte {
 	result = bytes.ReplaceAll(result, []byte("},{"), []byte(","))
 	result = bytes.ReplaceAll(result, []byte("}]"), []byte("}"))
 	result = bytes.ReplaceAll(result, []byte("[]"), []byte("{}"))
-
+	result = bytes.Trim(result, "\x00")
 	return result
 }
 

--- a/ship/helper_test.go
+++ b/ship/helper_test.go
@@ -19,6 +19,21 @@ func TestJsonFromEEBUSJson(t *testing.T) {
 	}
 }
 
+func TestJsonFromEEBUSJsonTrailingZeros(t *testing.T) {
+
+	bytes := []byte(`{"datagram":[{"header":[{"specificationVersion":"1.2.0"},{"addressSource":[{"device":"d:_i:3210_EVSE"},{"entity":[1,1]},{"feature":6}]},{"addressDestination":[{"device":"d:_i:3210_HEMS"},{"entity":[1]},{"feature":1}]},{"msgCounter":194},{"msgCounterReference":4890},{"cmdClassifier":"reply"}]},{"payload":[{"cmd":[[{"deviceClassificationManufacturerData":[{"deviceName":""},{"deviceCode":""},{"brandName":""},{"powerSource":"mains3Phase"}]}]]}]}]}`)
+	bytes = append(bytes, 0x00)
+
+	jsonTest := string(bytes[:])
+	jsonExpected := `{"datagram":{"header":{"specificationVersion":"1.2.0","addressSource":{"device":"d:_i:3210_EVSE","entity":[1,1],"feature":6},"addressDestination":{"device":"d:_i:3210_HEMS","entity":[1],"feature":1},"msgCounter":194,"msgCounterReference":4890,"cmdClassifier":"reply"},"payload":{"cmd":[{"deviceClassificationManufacturerData":{"deviceName":"","deviceCode":"","brandName":"","powerSource":"mains3Phase"}}]}}}`
+
+	var json = JsonFromEEBUSJson([]byte(jsonTest))
+
+	if string(json) != jsonExpected {
+		t.Errorf("\nExpected:\n  %s\ngot:\n  %s", jsonExpected, json)
+	}
+}
+
 func TestJsonIntoEEBUSJson(t *testing.T) {
 	jsonTest := `{"datagram":{"header":{"specificationVersion":"1.2.0","addressSource":{"device":"d:_i:3210_EVSE","entity":[1,1],"feature":6},"addressDestination":{"device":"d:_i:3210_HEMS","entity":[1],"feature":1},"msgCounter":194,"msgCounterReference":4890,"cmdClassifier":"reply"},"payload":{"cmd":[{"deviceClassificationManufacturerData":{"deviceName":"","deviceCode":"","brandName":"","powerSource":"mains3Phase"}}]}}}`
 	jsonExpected := `{"datagram":[{"header":[{"specificationVersion":"1.2.0"},{"addressSource":[{"device":"d:_i:3210_EVSE"},{"entity":[1,1]},{"feature":6}]},{"addressDestination":[{"device":"d:_i:3210_HEMS"},{"entity":[1]},{"feature":1}]},{"msgCounter":194},{"msgCounterReference":4890},{"cmdClassifier":"reply"}]},{"payload":[{"cmd":[[{"deviceClassificationManufacturerData":[{"deviceName":""},{"deviceCode":""},{"brandName":""},{"powerSource":"mains3Phase"}]}]]}]}]}`

--- a/ship/helper_test.go
+++ b/ship/helper_test.go
@@ -19,6 +19,7 @@ func TestJsonFromEEBUSJson(t *testing.T) {
 	}
 }
 
+// The PMCP device mistakenly adds an `0x00` byte at the end of many messages. Test if this is handled correctly
 func TestJsonFromEEBUSJsonTrailingZeros(t *testing.T) {
 
 	bytes := []byte(`{"datagram":[{"header":[{"specificationVersion":"1.2.0"},{"addressSource":[{"device":"d:_i:3210_EVSE"},{"entity":[1,1]},{"feature":6}]},{"addressDestination":[{"device":"d:_i:3210_HEMS"},{"entity":[1]},{"feature":1}]},{"msgCounter":194},{"msgCounterReference":4890},{"cmdClassifier":"reply"}]},{"payload":[{"cmd":[[{"deviceClassificationManufacturerData":[{"deviceName":""},{"deviceCode":""},{"brandName":""},{"powerSource":"mains3Phase"}]}]]}]}]}`)


### PR DESCRIPTION
Remove possible and erroneous trailing `\x00` character. This fixes connection issues with the Porsche Mobile Charger Plus (PMCP)

Fixes https://github.com/enbility/ship-go/issues/29