### PR TITLE
Improve closing of ship connection

### DIFF
--- a/ship/connection.go
+++ b/ship/connection.go
@@ -172,17 +172,15 @@ func (c *ShipConnection) CloseConnection(safe bool, code int, reason string) {
 
 			_ = c.sendShipModel(model.MsgTypeEnd, closeMessage)
 
-			if state != model.SmeStateError {
-				go func() {
-					// wait a bit to let it send
-					<-time.After(500 * time.Millisecond)
+			go func() {
+				// wait a bit to let it send
+				<-time.After(500 * time.Millisecond)
 
-					//
-					c.dataWriter.CloseDataConnection(4001, "close")
-					c.infoProvider.HandleConnectionClosed(c, handshakeEnd)
-				}()
-				return
-			}
+				//
+				c.dataWriter.CloseDataConnection(4001, "close")
+				c.infoProvider.HandleConnectionClosed(c, handshakeEnd)
+			}()
+			return
 		}
 
 		closeCode := 4001


### PR DESCRIPTION
When announcing closing of a connection is ignored by the remote device then the connection continued to be active.

This change tells the remote device that it has a max of 500ms to close the connection and will close the connection after this time automatically as well.

Fixes https://github.com/enbility/ship-go/issues/32