### PR TITLE
Add support for providing QR code text value

### DIFF
--- a/api/mdns.go
+++ b/api/mdns.go
@@ -32,6 +32,11 @@ type MdnsInterface interface {
 	AnnounceMdnsEntry() error
 	UnannounceMdnsEntry()
 	SetAutoAccept(bool)
+
+	// Returns the QR code text for the service
+	// as defined in SHIP Requirements for Installation Process V1.0.0
+	QRCodeText() string
+
 	RequestMdnsEntries()
 }
 

--- a/mdns/mdns_test.go
+++ b/mdns/mdns_test.go
@@ -66,6 +66,34 @@ func (s *MdnsSuite) Test_LongStrings() {
 	// Can't do an assertion check, as the result depends on the
 	// system this test is being ran on
 }
+
+func (s *MdnsSuite) Test_safeQRCodeKeyValue() {
+	result := s.sut.safeQRCodeKeyValue("key", "value")
+	assert.Equal(s.T(), "KEY:value;", result)
+
+	result = s.sut.safeQRCodeKeyValue("KEY", "val;ue")
+	assert.Equal(s.T(), "KEY:value;", result)
+
+	result = s.sut.safeQRCodeKeyValue("key", "")
+	assert.Equal(s.T(), "", result)
+}
+
+func (s *MdnsSuite) Test_deviceCategoriesString() {
+	result := s.sut.deviceCategoriesString([]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem})
+	assert.Equal(s.T(), "2", result)
+
+	result = s.sut.deviceCategoriesString([]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem, api.DeviceCategoryTypeEnergyManagementSystem})
+	assert.Equal(s.T(), "2,2", result)
+
+	result = s.sut.deviceCategoriesString([]api.DeviceCategoryType{})
+	assert.Equal(s.T(), "", result)
+}
+
+func (s *MdnsSuite) Test_QRCodeText() {
+	result := s.sut.QRCodeText()
+	assert.NotEqual(s.T(), "", result)
+}
+
 func (s *MdnsSuite) Test_AvahiOnly() {
 	s.sut.Shutdown()
 

--- a/mocks/MdnsInterface.go
+++ b/mocks/MdnsInterface.go
@@ -65,6 +65,51 @@ func (_c *MdnsInterface_AnnounceMdnsEntry_Call) RunAndReturn(run func() error) *
 	return _c
 }
 
+// QRCodeText provides a mock function with given fields:
+func (_m *MdnsInterface) QRCodeText() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for QRCodeText")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MdnsInterface_QRCodeText_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QRCodeText'
+type MdnsInterface_QRCodeText_Call struct {
+	*mock.Call
+}
+
+// QRCodeText is a helper method to define mock.On call
+func (_e *MdnsInterface_Expecter) QRCodeText() *MdnsInterface_QRCodeText_Call {
+	return &MdnsInterface_QRCodeText_Call{Call: _e.mock.On("QRCodeText")}
+}
+
+func (_c *MdnsInterface_QRCodeText_Call) Run(run func()) *MdnsInterface_QRCodeText_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MdnsInterface_QRCodeText_Call) Return(_a0 string) *MdnsInterface_QRCodeText_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MdnsInterface_QRCodeText_Call) RunAndReturn(run func() string) *MdnsInterface_QRCodeText_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RequestMdnsEntries provides a mock function with given fields:
 func (_m *MdnsInterface) RequestMdnsEntries() {
 	_m.Called()

--- a/mocks/mockgen_api.go
+++ b/mocks/mockgen_api.go
@@ -53,6 +53,20 @@ func (mr *MockMdnsInterfaceMockRecorder) AnnounceMdnsEntry() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnounceMdnsEntry", reflect.TypeOf((*MockMdnsInterface)(nil).AnnounceMdnsEntry))
 }
 
+// QRCodeText mocks base method.
+func (m *MockMdnsInterface) QRCodeText() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QRCodeText")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// QRCodeText indicates an expected call of QRCodeText.
+func (mr *MockMdnsInterfaceMockRecorder) QRCodeText() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QRCodeText", reflect.TypeOf((*MockMdnsInterface)(nil).QRCodeText))
+}
+
 // RequestMdnsEntries mocks base method.
 func (m *MockMdnsInterface) RequestMdnsEntries() {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The document SHIP Requirements for Installation Process 1.0 includes details on how a QR code should be generated to allow easier pairing.

This change adds a new public method `QRCodeText()` for the `MdnsManager` which provides the text content needed to generate the QR code