### PR TITLE
Improve websocket write handling

### DIFF
--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -128,6 +128,23 @@ func (s *WebsocketSuite) TestConnectionClose() {
 	assert.NotNil(s.T(), err)
 }
 
+func (s *WebsocketSuite) TestWriteBufferFull() {
+	amountNil := 0
+	amountNotNil := 0
+	for i := 0; i < 10000; i++ {
+		msg := []byte{1}
+		msg = append(msg, []byte("message")...)
+		err := s.sut.WriteMessageToWebsocketConnection(msg)
+		if err == nil {
+			amountNil++
+		} else {
+			amountNotNil++
+		}
+	}
+	assert.Greater(s.T(), amountNotNil, 0)
+	assert.Greater(s.T(), amountNil, 0)
+}
+
 func (s *WebsocketSuite) TestPingPeriod() {
 	isClosed, err := s.sut.IsDataConnectionClosed()
 	assert.Equal(s.T(), false, isClosed)


### PR DESCRIPTION
Increase the buffer size of the write channel to 1024. This way adding messages will never block if e.g. at the same time the connection is closed. If the buffer is full, return an error, as sending isn’t possible.

This fixes https://github.com/enbility/ship-go/issues/42