### PR TITLE
[zeroconf] allow browser to take Ifaces as an input

### DIFF
--- a/mdns/zeroconf.go
+++ b/mdns/zeroconf.go
@@ -86,7 +86,7 @@ func (z *ZeroconfProvider) chanListener(cb api.MdnsResolveCB) {
 	z.mux.Unlock()
 
 	go func() {
-		_ = zeroconf.Browse(z.ctx, shipZeroConfServiceType, shipZeroConfDomain, zcEntries, zcRemoved)
+		_ = zeroconf.Browse(z.ctx, shipZeroConfServiceType, shipZeroConfDomain, zcEntries, zcRemoved, zeroconf.SelectIfaces(z.ifaces))
 	}()
 
 	for {


### PR DESCRIPTION
The current implementation of the Zeroconf announcer takes z.Ifaces for selected interfaces while the browser does not. This would lead to the browser to always select all interfaces that exist during the set up of the mDNS instance, even if the user wants to only target specific interfaces.

This PR allows the browser to take z.Ifaces as an input during instantiation. If z.Ifaces is nil, it will assume all interfaces by default.

Fixes #49 