### PR TITLE
Improve accessMethods JSON parsing handling

### DIFF
--- a/ship/hs_access.go
+++ b/ship/hs_access.go
@@ -54,7 +54,7 @@ func (c *ShipConnection) handleAccessMethodsRequest() error {
 			Id: &c.localShipID,
 		},
 	}
-	
+
 	return c.sendShipModel(model.MsgTypeControl, accessMethods)
 }
 
@@ -64,20 +64,20 @@ func (c *ShipConnection) handleAccessMethodsResponse(accessMethods *model.Access
 	if accessMethods.AccessMethods.Id == nil {
 		return errors.New("Access methods response does not contain SHIP ID")
 	}
-	
+
 	remoteID := *accessMethods.AccessMethods.Id
-	
+
 	// If we already know the remote ID, verify it matches
 	if len(c.remoteShipID) > 0 && c.remoteShipID != remoteID {
 		return errors.New("SHIP id mismatch")
 	}
-	
+
 	// Save and report the SHIP ID if this is the first time we see it
 	if len(c.remoteShipID) == 0 {
 		c.remoteShipID = remoteID
 		c.infoProvider.ReportServiceShipID(c.remoteSKI, c.remoteShipID)
 	}
-	
+
 	return nil
 }
 

--- a/ship/hs_access.go
+++ b/ship/hs_access.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/enbility/ship-go/model"
 )
@@ -26,55 +25,98 @@ func (c *ShipConnection) handshakeAccessMethods_Init() {
 	c.setState(model.SmeAccessMethodsRequest, nil)
 }
 
+// detectAccessMethodsMessageType determines the type of access methods message
+// by parsing the JSON and checking which fields are present
+func detectAccessMethodsMessageType(data []byte) (string, error) {
+	var detector map[string]json.RawMessage
+	if err := json.Unmarshal(data, &detector); err != nil {
+		return "", fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	// Check for accessMethodsRequest first
+	if _, hasRequest := detector["accessMethodsRequest"]; hasRequest {
+		return "request", nil
+	}
+
+	// Check for accessMethods
+	if _, hasMethods := detector["accessMethods"]; hasMethods {
+		return "methods", nil
+	}
+
+	return "", errors.New("unknown message type: expected accessMethodsRequest or accessMethods")
+}
+
+// handleAccessMethodsRequest processes an incoming access methods request
+// by sending back our local access methods
+func (c *ShipConnection) handleAccessMethodsRequest() error {
+	accessMethods := model.AccessMethods{
+		AccessMethods: model.AccessMethodsType{
+			Id: &c.localShipID,
+		},
+	}
+	
+	return c.sendShipModel(model.MsgTypeControl, accessMethods)
+}
+
+// handleAccessMethodsResponse processes an incoming access methods response
+// by validating and storing the remote SHIP ID
+func (c *ShipConnection) handleAccessMethodsResponse(accessMethods *model.AccessMethods) error {
+	if accessMethods.AccessMethods.Id == nil {
+		return errors.New("Access methods response does not contain SHIP ID")
+	}
+	
+	remoteID := *accessMethods.AccessMethods.Id
+	
+	// If we already know the remote ID, verify it matches
+	if len(c.remoteShipID) > 0 && c.remoteShipID != remoteID {
+		return errors.New("SHIP id mismatch")
+	}
+	
+	// Save and report the SHIP ID if this is the first time we see it
+	if len(c.remoteShipID) == 0 {
+		c.remoteShipID = remoteID
+		c.infoProvider.ReportServiceShipID(c.remoteSKI, c.remoteShipID)
+	}
+	
+	return nil
+}
+
 func (c *ShipConnection) handshakeAccessMethods_Request(message []byte) {
 	_, data := c.parseMessage(message, true)
 
-	dataString := string(data)
-
-	if strings.Contains(dataString, "\"accessMethodsRequest\":{") {
-		methodsId := c.localShipID
-
-		accessMethods := model.AccessMethods{
-			AccessMethods: model.AccessMethodsType{
-				Id: &methodsId,
-			},
-		}
-		if err := c.sendShipModel(model.MsgTypeControl, accessMethods); err != nil {
-			c.endHandshakeWithError(err)
-		}
-		return
-	} else if strings.Contains(dataString, "\"accessMethods\":{") {
-		// compare SHIP ID to stored value on pairing. SKI + SHIP ID should be verified on connection
-		// otherwise close connection with error "close 4450: SHIP id mismatch"
-
-		var accessMethods model.AccessMethods
-		if err := json.Unmarshal([]byte(data), &accessMethods); err != nil {
-			c.endHandshakeWithError(err)
-			return
-		}
-
-		if accessMethods.AccessMethods.Id == nil {
-			c.endHandshakeWithError(errors.New("Access methods response does not contain SHIP ID"))
-			return
-		}
-
-		// if the ID string is empty, then we don't know it yet and can't be verified
-		if len(c.remoteShipID) > 0 && c.remoteShipID != *accessMethods.AccessMethods.Id {
-			c.endHandshakeWithError(errors.New("SHIP id mismatch"))
-			return
-		}
-
-		// save and report the SHIP ID
-		if len(c.remoteShipID) == 0 {
-			c.remoteShipID = *accessMethods.AccessMethods.Id
-
-			c.infoProvider.ReportServiceShipID(c.remoteSKI, c.remoteShipID)
-		}
-	} else {
-		c.endHandshakeWithError(fmt.Errorf("access methods: invalid response: %s", dataString))
+	// Determine message type using JSON parsing instead of string matching
+	msgType, err := detectAccessMethodsMessageType(data)
+	if err != nil {
+		c.endHandshakeWithError(err)
 		return
 	}
 
-	c.setState(model.SmeStateApproved, nil)
-	c.approveHandshake()
+	switch msgType {
+	case "request":
+		if err := c.handleAccessMethodsRequest(); err != nil {
+			c.endHandshakeWithError(err)
+			return
+		}
+		// Stay in current state waiting for response
+		return
+
+	case "methods":
+		var accessMethods model.AccessMethods
+		if err := json.Unmarshal(data, &accessMethods); err != nil {
+			c.endHandshakeWithError(err)
+			return
+		}
+
+		if err := c.handleAccessMethodsResponse(&accessMethods); err != nil {
+			c.endHandshakeWithError(err)
+			return
+		}
+
+		// Transition to approved state
+		c.setState(model.SmeStateApproved, nil)
+		c.approveHandshake()
+
+	default:
+		c.endHandshakeWithError(fmt.Errorf("access methods: unexpected message type: %s", msgType))
+	}
 }

--- a/ship/hs_access_json_test.go
+++ b/ship/hs_access_json_test.go
@@ -1,0 +1,123 @@
+package ship
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectAccessMethodsMessageType(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		expectedType  string
+		expectedError bool
+	}{
+		// AccessMethodsRequest tests
+		{
+			name:          "AccessMethodsRequest without spaces",
+			input:         []byte(`{"accessMethodsRequest":{}}`),
+			expectedType:  "request",
+			expectedError: false,
+		},
+		{
+			name:          "AccessMethodsRequest with spaces",
+			input:         []byte(`{"accessMethodsRequest": {}}`),
+			expectedType:  "request",
+			expectedError: false,
+		},
+		{
+			name:          "AccessMethodsRequest with multiple spaces",
+			input:         []byte(`{"accessMethodsRequest"  :  {  }}`),
+			expectedType:  "request",
+			expectedError: false,
+		},
+		{
+			name:          "AccessMethodsRequest with tabs",
+			input:         []byte(`{"accessMethodsRequest":	{}}`),
+			expectedType:  "request",
+			expectedError: false,
+		},
+		{
+			name:          "AccessMethodsRequest with newlines",
+			input:         []byte(`{
+				"accessMethodsRequest": {
+				}
+			}`),
+			expectedType:  "request",
+			expectedError: false,
+		},
+
+		// AccessMethods tests
+		{
+			name:          "AccessMethods without spaces",
+			input:         []byte(`{"accessMethods":{"id":"test"}}`),
+			expectedType:  "methods",
+			expectedError: false,
+		},
+		{
+			name:          "AccessMethods with spaces",
+			input:         []byte(`{"accessMethods": {"id": "test"}}`),
+			expectedType:  "methods",
+			expectedError: false,
+		},
+		{
+			name:          "AccessMethods with mixed whitespace",
+			input:         []byte(`{	"accessMethods"  :
+				{  "id"	: "test" }  }`),
+			expectedType:  "methods",
+			expectedError: false,
+		},
+
+		// Error cases
+		{
+			name:          "Empty object",
+			input:         []byte(`{}`),
+			expectedType:  "",
+			expectedError: true,
+		},
+		{
+			name:          "Invalid JSON",
+			input:         []byte(`{invalid json`),
+			expectedType:  "",
+			expectedError: true,
+		},
+		{
+			name:          "Wrong message type",
+			input:         []byte(`{"someOtherMessage": {}}`),
+			expectedType:  "",
+			expectedError: true,
+		},
+		{
+			name:          "Both message types present",
+			input:         []byte(`{"accessMethodsRequest": {}, "accessMethods": {"id": "test"}}`),
+			expectedType:  "request", // Should detect first one
+			expectedError: false,
+		},
+		{
+			name:          "Null value for accessMethods",
+			input:         []byte(`{"accessMethods": null}`),
+			expectedType:  "methods",
+			expectedError: false,
+		},
+		{
+			name:          "Array instead of object",
+			input:         []byte(`[]`),
+			expectedType:  "",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgType, err := detectAccessMethodsMessageType(tt.input)
+			
+			if tt.expectedError {
+				assert.Error(t, err, "Expected error but got none")
+			} else {
+				assert.NoError(t, err, "Expected no error but got: %v", err)
+				assert.Equal(t, tt.expectedType, msgType, "Message type mismatch")
+			}
+		})
+	}
+}

--- a/ship/hs_access_json_test.go
+++ b/ship/hs_access_json_test.go
@@ -39,8 +39,8 @@ func TestDetectAccessMethodsMessageType(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "AccessMethodsRequest with newlines",
-			input:         []byte(`{
+			name: "AccessMethodsRequest with newlines",
+			input: []byte(`{
 				"accessMethodsRequest": {
 				}
 			}`),
@@ -62,8 +62,8 @@ func TestDetectAccessMethodsMessageType(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "AccessMethods with mixed whitespace",
-			input:         []byte(`{	"accessMethods"  :
+			name: "AccessMethods with mixed whitespace",
+			input: []byte(`{	"accessMethods"  :
 				{  "id"	: "test" }  }`),
 			expectedType:  "methods",
 			expectedError: false,
@@ -111,7 +111,7 @@ func TestDetectAccessMethodsMessageType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			msgType, err := detectAccessMethodsMessageType(tt.input)
-			
+
 			if tt.expectedError {
 				assert.Error(t, err, "Expected error but got none")
 			} else {

--- a/ship/hs_access_test.go
+++ b/ship/hs_access_test.go
@@ -206,7 +206,6 @@ func (s *AccessSuite) Test_Methods_ArrayFormat_WithSpaces() {
 	// EEBUS JSON with spaces after colons
 	// After JsonFromEEBUSJson conversion: {"accessMethods": {"id": "i:46353_u:1234567890"}}
 	// This SHOULD succeed but currently fails because string check looks for "accessMethods":{" (no space)
-	// TODO: Fix implementation to handle JSON with spaces
 	eebusMsg := []byte{model.MsgTypeControl}
 	eebusMsg = append(eebusMsg, []byte(`{"accessMethods": [{"id": "i:46353_u:1234567890"}]}`)...)
 
@@ -244,7 +243,6 @@ func (s *AccessSuite) Test_AccessMethodsRequest_WithSpaces() {
 	s.sut.handleState(false, eebusMsg)
 
 	// Should fail due to spacing mismatch
-	// TODO: Fix implementation to handle JSON with spaces
 	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
 	assert.Equal(s.T(), model.SmeAccessMethodsRequest, s.sut.getState())
 	assert.NotNil(s.T(), s.lastMessage())

--- a/ship/hs_access_test.go
+++ b/ship/hs_access_test.go
@@ -196,3 +196,71 @@ func (s *AccessSuite) Test_Methods_NoShipID() {
 	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
 	assert.Equal(s.T(), model.SmeStateComplete, s.sut.getState())
 }
+
+func (s *AccessSuite) Test_Methods_ArrayFormat_WithSpaces() {
+	reader := mocks.NewShipConnectionDataReaderInterface(s.T())
+	s.mockShipInfo.EXPECT().SetupRemoteDevice(mock.Anything, mock.Anything).Return(reader)
+	s.sut.setState(model.SmeAccessMethodsRequest, nil)
+	s.sut.remoteShipID = "i:46353_u:1234567890"
+
+	// EEBUS JSON with spaces after colons
+	// After JsonFromEEBUSJson conversion: {"accessMethods": {"id": "i:46353_u:1234567890"}}
+	// This SHOULD succeed but currently fails because string check looks for "accessMethods":{" (no space)
+	// TODO: Fix implementation to handle JSON with spaces
+	eebusMsg := []byte{model.MsgTypeControl}
+	eebusMsg = append(eebusMsg, []byte(`{"accessMethods": [{"id": "i:46353_u:1234567890"}]}`)...)
+
+	s.sut.handleState(false, eebusMsg)
+
+	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
+	assert.Equal(s.T(), model.SmeStateComplete, s.sut.getState())
+}
+
+func (s *AccessSuite) Test_Methods_ArrayFormat_NoSpaces() {
+	reader := mocks.NewShipConnectionDataReaderInterface(s.T())
+	s.mockShipInfo.EXPECT().SetupRemoteDevice(mock.Anything, mock.Anything).Return(reader)
+	s.sut.setState(model.SmeAccessMethodsRequest, nil)
+	s.sut.remoteShipID = "i:46353_u:1234567890"
+
+	// EEBUS JSON without spaces after colons
+	// After JsonFromEEBUSJson conversion: {"accessMethods":{"id":"i:46353_u:1234567890"}}
+	// This succeeds because string check matches "accessMethods":{"
+	eebusMsg := []byte{model.MsgTypeControl}
+	eebusMsg = append(eebusMsg, []byte(`{"accessMethods":[{"id":"i:46353_u:1234567890"}]}`)...)
+
+	s.sut.handleState(false, eebusMsg)
+
+	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
+	assert.Equal(s.T(), model.SmeStateComplete, s.sut.getState())
+}
+
+func (s *AccessSuite) Test_AccessMethodsRequest_WithSpaces() {
+	s.sut.setState(model.SmeAccessMethodsRequest, nil)
+
+	// Test accessMethodsRequest with spaces - should fail
+	eebusMsg := []byte{model.MsgTypeControl}
+	eebusMsg = append(eebusMsg, []byte(`{"accessMethodsRequest": {}}`)...)
+
+	s.sut.handleState(false, eebusMsg)
+
+	// Should fail due to spacing mismatch
+	// TODO: Fix implementation to handle JSON with spaces
+	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
+	assert.Equal(s.T(), model.SmeAccessMethodsRequest, s.sut.getState())
+	assert.NotNil(s.T(), s.lastMessage())
+}
+
+func (s *AccessSuite) Test_AccessMethodsRequest_NoSpaces() {
+	s.sut.setState(model.SmeAccessMethodsRequest, nil)
+
+	// Test accessMethodsRequest without spaces - should succeed
+	eebusMsg := []byte{model.MsgTypeControl}
+	eebusMsg = append(eebusMsg, []byte(`{"accessMethodsRequest":{}}`)...)
+
+	s.sut.handleState(false, eebusMsg)
+
+	// Should send response and stay in same state
+	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
+	assert.Equal(s.T(), model.SmeAccessMethodsRequest, s.sut.getState())
+	assert.NotNil(s.T(), s.lastMessage())
+}


### PR DESCRIPTION
The previous implementation simply checked for strings to determine the message time. But this is not safe, as valid json variations could be ignored leaving the system in an undefined state.

This change introduces detecting the message type and safely parse all valid JSON variations.