### PR TITLE
🐛 fix: Add delay in test teardown to prevent race condition

### DIFF
--- a/ship/hs_hello_server_test.go
+++ b/ship/hs_hello_server_test.go
@@ -87,6 +87,12 @@ func (s *HelloSuite) BeforeTest(suiteName, testName string) {
 func (s *HelloSuite) AfterTest(suiteName, testName string) {
 	s.sut.stopHandshakeTimer()
 	assert.Equal(s.T(), false, s.sut.getHandshakeTimerRunning())
+	
+	// If the state is AbortDone, wait for the goroutine to complete
+	// to avoid race conditions with mock verification
+	if s.sut.getState() == model.SmeHelloStateAbortDone {
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func (s *HelloSuite) Test_InitialState() {


### PR DESCRIPTION
Wait for goroutine completion when test ends in AbortDone state to avoid race between mock verification and connection cleanup