### PR TITLE
Critical security and other bugfixes

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -9,13 +9,13 @@ import "errors"
 var (
 	// ErrConnectionNotInitialized indicates a connection operation was attempted before initialization
 	ErrConnectionNotInitialized = errors.New("connection not initialized")
-	
+
 	// ErrConnectionClosed indicates an operation was attempted on a closed connection
 	ErrConnectionClosed = errors.New("connection closed")
-	
+
 	// ErrConnectionTimeout indicates a connection operation timed out
 	ErrConnectionTimeout = errors.New("connection timeout")
-	
+
 	// ErrBufferFull indicates a message buffer is full
 	ErrBufferFull = errors.New("buffer full")
 )
@@ -24,10 +24,10 @@ var (
 var (
 	// ErrInvalidCertificate indicates certificate validation failed
 	ErrInvalidCertificate = errors.New("invalid certificate")
-	
+
 	// ErrInvalidSKI indicates an invalid or missing SKI
 	ErrInvalidSKI = errors.New("invalid SKI")
-	
+
 	// ErrNotPaired indicates the remote service is not paired
 	ErrNotPaired = errors.New("remote service not paired")
 )
@@ -36,10 +36,16 @@ var (
 var (
 	// ErrInvalidHandshake indicates a handshake protocol violation
 	ErrInvalidHandshake = errors.New("invalid handshake")
-	
+
 	// ErrInvalidProtocolMessage indicates a malformed protocol message
 	ErrInvalidProtocolMessage = errors.New("invalid protocol message")
-	
+
 	// ErrUnsupportedPinState indicates an unsupported PIN state was received
 	ErrUnsupportedPinState = errors.New("unsupported PIN state")
+)
+
+// SHIP Pairing Service errors following ship-go error pattern
+var (
+	// Configuration errors
+	ErrInvalidTargetFingerprint = errors.New("invalid target fingerprint")
 )

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -2,6 +2,7 @@ package cert
 
 //nolint:gosec
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -35,13 +36,10 @@ func CreateCertificate(organizationalUnit, organization, country, commonName str
 	}
 
 	// Create the EEBUS service SKI using the public key
-	publicKey, err := privateKey.PublicKey.ECDH()
+	ski, err := skiFromECDSAKey(&privateKey.PublicKey)
 	if err != nil {
 		return tls.Certificate{}, err
 	}
-	// SHIP 12.2: Required to be created according to RFC 3280 4.2.1.2
-	// #nosec G401
-	ski := sha1.Sum(publicKey.Bytes())
 
 	subject := pkix.Name{
 		OrganizationalUnit: []string{organizationalUnit},
@@ -67,7 +65,7 @@ func CreateCertificate(organizationalUnit, organization, country, commonName str
 		KeyUsage:              x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		SubjectKeyId:          ski[:],
+		SubjectKeyId:          []byte(ski),
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
@@ -85,16 +83,51 @@ func CreateCertificate(organizationalUnit, organization, country, commonName str
 }
 
 func SkiFromCertificate(cert *x509.Certificate) (string, error) {
+	unknownSubject := "unknown"
+	subject := cert.Subject.String()
+	if subject == "" {
+		subject = unknownSubject
+	}
+
 	// check if the clients certificate provides a SKI
 	subjectKeyId := cert.SubjectKeyId
 	if len(subjectKeyId) != 20 {
-		subject := cert.Subject.String()
-		if subject == "" {
-			subject = "unknown"
-		}
-		return "", fmt.Errorf("%w (subject: %s, SKI length: %d, expected: 20)", 
+		return "", fmt.Errorf("%w (subject: %s, SKI length: %d, expected: 20)",
 			api.ErrInvalidSKI, subject, len(subjectKeyId))
 	}
 
+	// calculate the SKI from the public key of the certificate
+
+	// Convert ECDSA key to ECDH for raw bytes (same as CreateCertificate)
+	ecdsaKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return "", fmt.Errorf("unsupported key type for SHIP: expected ECDSA")
+	}
+
+	ski, err := skiFromECDSAKey(ecdsaKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert ECDSA key: %w", err)
+	}
+
+	// now check if the subjectKeyId and the ski match
+	if !bytes.Equal(subjectKeyId, []byte(ski)) {
+		return "", fmt.Errorf("%w (subject: %s, SKI: %0x, expected: %0x)",
+			api.ErrInvalidSKI, subject, ski[:], subjectKeyId)
+	}
+
 	return fmt.Sprintf("%0x", subjectKeyId), nil
+}
+
+func skiFromECDSAKey(ecdsaKey *ecdsa.PublicKey) (string, error) {
+	// Convert ECDSA key to ECDH for raw bytes (same as CreateCertificate)
+	ecdhKey, err := ecdsaKey.ECDH()
+	if err != nil {
+		return "", fmt.Errorf("failed to convert ECDSA key: %w", err)
+	}
+
+	// Calculate SHA-1 per RFC 3280 4.2.1.2 method (1)
+	// #nosec G401 - SHA1 required by SHIP specification
+	ski := sha1.Sum(ecdhKey.Bytes())
+
+	return string(ski[:]), nil
 }

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/enbility/ship-go/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 ) // #nosec G505
@@ -53,6 +55,29 @@ func (c *CertSuite) Test_SkiFromCertificate() {
 	assert.Equal(c.T(), "", ski)
 }
 
+func (c *CertSuite) Test_SkiFromCertificate_EmptySubject() {
+	cert := &x509.Certificate{
+		SubjectKeyId: []byte{1, 2, 3},
+		Subject:      pkix.Name{},
+	}
+
+	ski, err := SkiFromCertificate(cert)
+	assert.Error(c.T(), err)
+	assert.Equal(c.T(), "", ski)
+	assert.Contains(c.T(), err.Error(), "unknown")
+}
+
+func (c *CertSuite) Test_ValidateFingerprint_CalculateFingerprintError() {
+	cert := &x509.Certificate{
+		Raw: []byte{},
+	}
+
+	err := ValidateFingerprint(cert, "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")
+	assert.Error(c.T(), err)
+}
+
+// createInvalidCertificate creates a certificate with intentionally invalid SKI length (19 bytes instead of 20)
+// This is used to test the SKI validation error path in SkiFromCertificate
 func createInvalidCertificate(organizationalUnit, organization, country, commonName string) (tls.Certificate, error) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -107,4 +132,218 @@ func createInvalidCertificate(organizationalUnit, organization, country, commonN
 	}
 
 	return tlsCertificate, nil
+}
+
+// Test_SkiFromCertificate_NonECDSAKey tests error handling for non-ECDSA keys
+func (c *CertSuite) Test_SkiFromCertificate_NonECDSAKey() {
+	// Create a certificate with RSA key instead of ECDSA
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(c.T(), err)
+
+	// Create certificate with RSA key
+	template := x509.Certificate{
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		SubjectKeyId:          []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, // 20 bytes
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &rsaKey.PublicKey, rsaKey)
+	assert.Nil(c.T(), err)
+
+	cert, err := x509.ParseCertificate(certBytes)
+	assert.Nil(c.T(), err)
+
+	// This should fail because the key is not ECDSA
+	ski, err := SkiFromCertificate(cert)
+	assert.NotNil(c.T(), err)
+	assert.Equal(c.T(), "", ski)
+	assert.Contains(c.T(), err.Error(), "unsupported key type for SHIP: expected ECDSA")
+}
+
+// Test_SkiFromCertificate_SKIMismatch tests SKI validation errors
+func (c *CertSuite) Test_SkiFromCertificate_SKIMismatch() {
+	// Create a valid ECDSA key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.Nil(c.T(), err)
+
+	// Calculate correct SKI
+	ecdhKey, err := privateKey.PublicKey.ECDH()
+	assert.Nil(c.T(), err)
+	correctSki := sha1.Sum(ecdhKey.Bytes()) // #nosec G401
+
+	// Create certificate with WRONG SKI (correct length but wrong value)
+	wrongSki := make([]byte, 20)
+	copy(wrongSki, correctSki[:])
+	wrongSki[0] = ^wrongSki[0] // Flip first byte to make it wrong
+
+	template := x509.Certificate{
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-mismatch"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		SubjectKeyId:          wrongSki,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	assert.Nil(c.T(), err)
+
+	cert, err := x509.ParseCertificate(certBytes)
+	assert.Nil(c.T(), err)
+
+	// This should fail because SKI doesn't match calculated value
+	ski, err := SkiFromCertificate(cert)
+	assert.NotNil(c.T(), err)
+	assert.Equal(c.T(), "", ski)
+	assert.Contains(c.T(), err.Error(), "invalid SKI")
+	assert.Contains(c.T(), err.Error(), "test-mismatch")
+}
+
+// Test_SkiFromCertificate_InvalidSKILength tests certificates with invalid SKI lengths
+func (c *CertSuite) Test_SkiFromCertificate_InvalidSKILength() {
+	testCases := []struct {
+		name      string
+		skiLength int
+	}{
+		{"too_short", 19},
+		{"too_long", 21},
+		{"empty", 0},
+		{"way_too_short", 5},
+		{"way_too_long", 50},
+	}
+
+	for _, tc := range testCases {
+		c.T().Run(tc.name, func(t *testing.T) {
+			// Create certificate with invalid SKI length
+			invalidSki := make([]byte, tc.skiLength)
+			for i := range invalidSki {
+				invalidSki[i] = byte(i + 1)
+			}
+
+			cert := &x509.Certificate{
+				SubjectKeyId: invalidSki,
+				Subject:      pkix.Name{CommonName: "invalid-length"},
+			}
+
+			ski, err := SkiFromCertificate(cert)
+			assert.Error(t, err)
+			assert.Equal(t, "", ski)
+			assert.Contains(t, err.Error(), "invalid SKI")
+			assert.Contains(t, err.Error(), "invalid-length")
+			assert.Contains(t, err.Error(), "expected: 20")
+		})
+	}
+}
+
+// Test_skiFromECDSAKey_Success tests the successful path
+func (c *CertSuite) Test_skiFromECDSAKey_Success() {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.Nil(c.T(), err)
+
+	ski, err := skiFromECDSAKey(&privateKey.PublicKey)
+	assert.Nil(c.T(), err)
+	assert.Len(c.T(), ski, 20) // SHA-1 produces 20 bytes
+
+	// Verify SKI is deterministic
+	ski2, err := skiFromECDSAKey(&privateKey.PublicKey)
+	assert.Nil(c.T(), err)
+	assert.Equal(c.T(), ski, ski2)
+}
+
+// Test_skiFromECDSAKey_SFailure tests the failure path for skiFromECDSAKey
+func (c *CertSuite) Test_skiFromECDSAKey_SFailure() {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.Nil(c.T(), err)
+
+	// Modify the public key to trigger failure
+	ecdsaKey := &privateKey.PublicKey
+	ecdsaKey.Curve = elliptic.P384() // Change curve to induce failure
+
+	ski, err := skiFromECDSAKey(ecdsaKey)
+	assert.NotNil(c.T(), err)
+	assert.Equal(c.T(), "", ski)
+	assert.Contains(c.T(), err.Error(), "failed to convert ECDSA key")
+}
+
+// Test_SkiFromCertificate_ErrorIntegration demonstrates comprehensive error scenarios
+func (c *CertSuite) Test_SkiFromCertificate_ErrorIntegration() {
+	// Test that all error paths return appropriate api.ErrInvalidSKI errors
+	testCases := []struct {
+		name        string
+		cert        *x509.Certificate
+		expectedErr string
+	}{
+		{
+			name: "nil_certificate",
+			cert: &x509.Certificate{
+				SubjectKeyId: nil,
+				Subject:      pkix.Name{CommonName: "nil-ski"},
+			},
+			expectedErr: "invalid SKI",
+		},
+		{
+			name: "zero_length_ski",
+			cert: &x509.Certificate{
+				SubjectKeyId: []byte{},
+				Subject:      pkix.Name{CommonName: "empty-ski"},
+			},
+			expectedErr: "invalid SKI",
+		},
+	}
+
+	for _, tc := range testCases {
+		c.T().Run(tc.name, func(t *testing.T) {
+			ski, err := SkiFromCertificate(tc.cert)
+			assert.Error(t, err)
+			assert.Equal(t, "", ski)
+			assert.Contains(t, err.Error(), tc.expectedErr)
+			// Verify it's the expected error type
+			assert.ErrorIs(t, err, api.ErrInvalidSKI)
+		})
+	}
+}
+
+// Test_CertificateCreationEdgeCases tests certificate creation with various inputs
+func (c *CertSuite) Test_CertificateCreationEdgeCases() {
+	// Test certificate creation with edge case inputs
+	testCases := []struct {
+		name    string
+		ou      string
+		org     string
+		country string
+		cn      string
+	}{
+		{"empty_fields", "", "", "", ""},
+		{"unicode_content", "测试部门", "Test Org", "CN", "device-测试"},
+		{"long_strings", string(make([]byte, 100)), string(make([]byte, 100)), "US", string(make([]byte, 50))},
+		{"special_chars", "OU-123!@#", "Org & Co.", "DE", "device_model-serial#123"},
+	}
+
+	for _, tc := range testCases {
+		c.T().Run(tc.name, func(t *testing.T) {
+			// All these should succeed - CreateCertificate is robust
+			cert, err := CreateCertificate(tc.ou, tc.org, tc.country, tc.cn)
+			assert.Nil(t, err)
+			assert.NotEqual(t, tls.Certificate{}, cert)
+
+			// Verify certificate is valid
+			leaf, err := x509.ParseCertificate(cert.Certificate[0])
+			assert.Nil(t, err)
+			assert.Equal(t, tc.cn, leaf.Subject.CommonName)
+
+			// Verify SKI extraction works
+			ski, err := SkiFromCertificate(leaf)
+			assert.Nil(t, err)
+			assert.Len(t, ski, 40) // 20 bytes = 40 hex chars
+		})
+	}
 }

--- a/cert/fingerprint.go
+++ b/cert/fingerprint.go
@@ -1,0 +1,64 @@
+package cert
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"strings"
+
+	"github.com/enbility/ship-go/api"
+)
+
+// FingerprintFromCertificate calculates SHA-256 fingerprint of the given certificate
+// Per SHIP spec section 6.2: SHA-256 hash of DER-encoded certificate
+// Returns uppercase hex string as required by SHIP spec
+func FingerprintFromCertificate(cert *x509.Certificate) (string, error) {
+	if cert == nil {
+		return "", api.ErrInvalidCertificate
+	}
+
+	// Calculate SHA-256 hash of DER-encoded certificate per SHIP spec section 6.2
+	hash := sha256.Sum256(cert.Raw)
+
+	// Convert to uppercase hex string per SHIP spec requirements
+	fingerprint := strings.ToUpper(hex.EncodeToString(hash[:]))
+
+	return fingerprint, nil
+}
+
+// ValidateFingerprint validates that a certificate matches the expected fingerprint
+// expectedFingerprint must be a 64-character uppercase hex string per SHIP spec
+func ValidateFingerprint(cert *x509.Certificate, expectedFingerprint string) error {
+	if cert == nil {
+		return api.ErrInvalidCertificate
+	}
+
+	if expectedFingerprint == "" {
+		return api.ErrInvalidTargetFingerprint
+	}
+
+	// Validate hex format (64 characters, uppercase)
+	if len(expectedFingerprint) != 64 {
+		return api.ErrInvalidTargetFingerprint
+	}
+
+	// Check for valid hex characters (uppercase only per SHIP spec)
+	for _, char := range expectedFingerprint {
+		if (char < '0' || char > '9') && (char < 'A' || char > 'F') {
+			return api.ErrInvalidTargetFingerprint
+		}
+	}
+
+	// Calculate actual fingerprint
+	actualFingerprint, err := FingerprintFromCertificate(cert)
+	if err != nil {
+		return err
+	}
+
+	// Compare fingerprints (case-sensitive per SHIP spec)
+	if actualFingerprint != expectedFingerprint {
+		return api.ErrInvalidTargetFingerprint
+	}
+
+	return nil
+}

--- a/cert/fingerprint_test.go
+++ b/cert/fingerprint_test.go
@@ -1,0 +1,246 @@
+package cert
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/enbility/ship-go/api"
+)
+
+// FingerprintTestSuite contains tests for certificate fingerprint operations
+// Uses test certificates from SHIP Pairing Service specification Annex A
+type FingerprintTestSuite struct {
+	suite.Suite
+	devACert *x509.Certificate // devA certificate from spec
+	devZCert *x509.Certificate // devZ certificate from spec
+}
+
+func TestFingerprintTestSuite(t *testing.T) {
+	suite.Run(t, new(FingerprintTestSuite))
+}
+
+func (suite *FingerprintTestSuite) SetupSuite() {
+	// Load test certificates from SHIP specification Annex A
+	var err error
+
+	// devA certificate from SHIP spec Annex A.1
+	devAPEM := `-----BEGIN CERTIFICATE-----
+MIICJjCCAcugAwIBAgIURCTotMcqCC1Dt8VqkoywEXiXX2QwCgYIKoZIzj0EAwIw
+aDELMAkGA1UEBhMCREUxDDAKBgNVBAgMA05SVzEQMA4GA1UEBwwHQ29sb2duZTEV
+MBMGA1UECgwMRVhBTVBMRUJSQU5EMSIwIAYDVQQDDBlFRUIwMWRldkE4MTQtQzgy
+NzdIMDA4Ri0zMB4XDTI1MDgxMTE2NTQwOVoXDTI5MDgxMTE2NTQwOVowaDELMAkG
+A1UEBhMCREUxDDAKBgNVBAgMA05SVzEQMA4GA1UEBwwHQ29sb2duZTEVMBMGA1UE
+CgwMRVhBTVBMRUJSQU5EMSIwIAYDVQQDDBlFRUIwMWRldkE4MTQtQzgyNzdIMDA4
+Ri0zMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsKOrknwvjOfO+ihEu9EIIwhM
+rJraXone1kWiRA1DMVZK7A1k0rlEmCVL1XBOM7/wcloIrXnYX7iCqN3oBuarSKNT
+MFEwHQYDVR0OBBYEFKgFVqJD9Xyhew1Xelm3EbeetIVsMB8GA1UdIwQYMBaAFKgF
+VqJD9Xyhew1Xelm3EbeetIVsMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwID
+SQAwRgIhAIc7Is5jXiphSqXqK0V4yu5H2D+JxHBuLWDb74TnsKXOAiEAi0yLNr4z
+YyfuxNevdBQr+PkpeskDrpJaAaUPg81JlQg=
+-----END CERTIFICATE-----`
+
+	// devZ certificate from SHIP spec Annex A.2
+	devZPEM := `-----BEGIN CERTIFICATE-----
+MIICLjCCAdOgAwIBAgIUN8jFQuYTDfjInHKhQQQkNVMkHRAwCgYIKoZIzj0EAwIw
+bDELMAkGA1UEBhMCREUxDDAKBgNVBAgMA05SVzEQMA4GA1UEBwwHQ29sb2duZTEa
+MBgGA1UECgwRT1RIRVJFWEFNUExFQlJBTkQxITAfBgNVBAMMGEVFQjAyc3RiNTQt
+NDM2NTJiay0yLWd0MTAeFw0yNTA4MTExNTQ4MjlaFw0yOTA4MTExNTQ4MjlaMGwx
+CzAJBgNVBAYTAkRFMQwwCgYDVQQIDANOUlcxEDAOBgNVBAcMB0NvbG9nbmUxGjAY
+BgNVBAoMEU9USEVSRVhBTVBMRUJSQU5EMSEwHwYDVQQDDBhFRUIwMnN0YjU0LTQz
+NjUyYmstMi1ndDEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARB4qKF7gkB0dpc
+p7aGTT3YnAX2Im5HE3mtqKzDOuPoSl+YG19hpumso11J4T6iwjX2oORjrxFPmR3P
+Pd1TAOX7o1MwUTAdBgNVHQ4EFgQUvehlF5Rzk0Fr3BVbMzgiQyN3FRcwHwYDVR0j
+BBgwFoAUvehlF5Rzk0Fr3BVbMzgiQyN3FRcwDwYDVR0TAQH/BAUwAwEB/zAKBggq
+hkjOPQQDAgNJADBGAiEAmFBWkuUyLe9546+5uwpyuOVi7fk6ZI3ahNhAs+FQJJMC
+IQCqkzJAxrjNHJ3dcyQGsP5CSskTrVtTbqnTR3DbxvxAQQ==
+-----END CERTIFICATE-----`
+
+	suite.devACert, err = parsePEMCertificate(devAPEM)
+	assert.NoError(suite.T(), err, "devA certificate should parse successfully")
+
+	suite.devZCert, err = parsePEMCertificate(devZPEM)
+	assert.NoError(suite.T(), err, "devZ certificate should parse successfully")
+}
+
+func (suite *FingerprintTestSuite) TestCalculateFingerprint_SpecificationTestVectors() {
+	// Test fingerprint calculation with exact values from SHIP spec Annex A
+
+	tests := []struct {
+		name                string
+		cert                *x509.Certificate
+		expectedFingerprint string
+	}{
+		{
+			name:                "devA certificate fingerprint",
+			cert:                suite.devACert,
+			expectedFingerprint: "C74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD1384338943",
+		},
+		{
+			name:                "devZ certificate fingerprint",
+			cert:                suite.devZCert,
+			expectedFingerprint: "2CC72E781F7A7D2A08D50196C50FEDF0F7BA583F43F76C8C0DDEC9EEF0D005B4",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			fingerprint, err := FingerprintFromCertificate(tt.cert)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedFingerprint, fingerprint,
+				"fingerprint must match SHIP specification test vector")
+		})
+	}
+}
+
+func (suite *FingerprintTestSuite) TestValidateFingerprint() {
+	// Test validation with correct fingerprint
+	expectedFingerprint := "C74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD1384338943"
+	err := ValidateFingerprint(suite.devACert, expectedFingerprint)
+	assert.NoError(suite.T(), err, "validation should succeed with correct fingerprint")
+
+	// Test validation with incorrect fingerprint
+	wrongFingerprint := "AAAA7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD1384338943"
+	err = ValidateFingerprint(suite.devACert, wrongFingerprint)
+	assert.Error(suite.T(), err, "validation should fail with incorrect fingerprint")
+	assert.Equal(suite.T(), api.ErrInvalidTargetFingerprint, err)
+
+	// Test validation with invalid hex format
+	invalidFingerprint := "not-hex-format"
+	err = ValidateFingerprint(suite.devACert, invalidFingerprint)
+	assert.Error(suite.T(), err, "validation should fail with invalid hex format")
+}
+
+func (suite *FingerprintTestSuite) TestFingerprintCalculation_EdgeCases() {
+	// Test with nil certificate
+	_, err := FingerprintFromCertificate(nil)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), api.ErrInvalidCertificate, err)
+
+	// Test validation with nil certificate
+	err = ValidateFingerprint(nil, "C74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD1384338943")
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), api.ErrInvalidCertificate, err)
+
+	// Test validation with empty fingerprint
+	err = ValidateFingerprint(suite.devACert, "")
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), api.ErrInvalidTargetFingerprint, err)
+}
+
+func (suite *FingerprintTestSuite) TestFingerprintHexEncoding() {
+	// Calculate fingerprint for devA certificate
+	fingerprint, err := FingerprintFromCertificate(suite.devACert)
+	assert.NoError(suite.T(), err)
+
+	// Verify format: 64 uppercase hex characters
+	assert.Len(suite.T(), fingerprint, 64, "fingerprint should be 64 characters (SHA-256)")
+
+	// Verify all characters are uppercase hex
+	for _, char := range fingerprint {
+		assert.True(suite.T(),
+			(char >= '0' && char <= '9') || (char >= 'A' && char <= 'F'),
+			"fingerprint must contain only uppercase hex characters")
+	}
+
+	// Verify no lowercase characters
+	for _, char := range fingerprint {
+		assert.False(suite.T(), char >= 'a' && char <= 'f',
+			"fingerprint must not contain lowercase characters")
+	}
+}
+
+func (suite *FingerprintTestSuite) TestFingerprintConsistency() {
+	// Test that multiple calculations of the same certificate produce identical results
+	fingerprint1, err := FingerprintFromCertificate(suite.devACert)
+	assert.NoError(suite.T(), err)
+
+	fingerprint2, err := FingerprintFromCertificate(suite.devACert)
+	assert.NoError(suite.T(), err)
+
+	assert.Equal(suite.T(), fingerprint1, fingerprint2,
+		"multiple calculations should produce identical results")
+}
+
+func (suite *FingerprintTestSuite) TestValidateFingerprint_FormatValidation() {
+	// Test validation with different invalid formats
+	invalidFormats := []struct {
+		name        string
+		fingerprint string
+		description string
+	}{
+		{
+			name:        "too_short",
+			fingerprint: "C74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD138433894",
+			description: "63 characters instead of 64",
+		},
+		{
+			name:        "too_long",
+			fingerprint: "C74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD13843389433",
+			description: "65 characters instead of 64",
+		},
+		{
+			name:        "lowercase",
+			fingerprint: "c74b7855d3479415f62cc01e5f6d9a93ebc676057d85417ada16fd1384338943",
+			description: "lowercase hex characters",
+		},
+		{
+			name:        "mixed_case",
+			fingerprint: "C74B7855d3479415F62CC01E5F6D9A93ebc676057D85417ADA16FD1384338943",
+			description: "mixed case hex characters",
+		},
+		{
+			name:        "invalid_chars",
+			fingerprint: "G74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD1384338943",
+			description: "contains 'G' which is not hex",
+		},
+		{
+			name:        "with_colons",
+			fingerprint: "C7:4B:78:55:D3:47:94:15:F6:2C:C0:1E:5F:6D:9A:93:EB:C6:76:05:7D:85:41:7A:DA:16:FD:13:84:33:89:43",
+			description: "hex with colons (common format but not SHIP spec)",
+		},
+	}
+
+	for _, tc := range invalidFormats {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			err := ValidateFingerprint(suite.devACert, tc.fingerprint)
+			assert.Error(t, err, "validation should fail for %s", tc.description)
+			assert.Equal(t, api.ErrInvalidTargetFingerprint, err)
+		})
+	}
+}
+
+func (suite *FingerprintTestSuite) TestValidateFingerprint_CaseSensitivity() {
+	// SHIP spec requires uppercase hex, verify case sensitivity
+	uppercaseFingerprint := "C74B7855D3479415F62CC01E5F6D9A93EBC676057D85417ADA16FD1384338943"
+	lowercaseFingerprint := "c74b7855d3479415f62cc01e5f6d9a93ebc676057d85417ada16fd1384338943"
+
+	// Uppercase should succeed
+	err := ValidateFingerprint(suite.devACert, uppercaseFingerprint)
+	assert.NoError(suite.T(), err, "validation should succeed with correct uppercase format")
+
+	// Lowercase should fail per SHIP spec requirements
+	err = ValidateFingerprint(suite.devACert, lowercaseFingerprint)
+	assert.Error(suite.T(), err, "validation should fail with lowercase format")
+	assert.Equal(suite.T(), api.ErrInvalidTargetFingerprint, err)
+}
+
+/* Helper Functions */
+
+// parsePEMCertificate parses a PEM-encoded certificate
+func parsePEMCertificate(pemData string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, api.ErrInvalidCertificate
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, api.ErrInvalidCertificate
+	}
+
+	return cert, nil
+}

--- a/hub/hub_connections_client.go
+++ b/hub/hub_connections_client.go
@@ -68,14 +68,14 @@ func validateRemoteCertificate(remoteCerts []*x509.Certificate, expectedSKI stri
 		}
 	}
 
-	if _, err := cert.SkiFromCertificate(remoteCerts[0]); err != nil {
+	remoteSKI, err := cert.SkiFromCertificate(remoteCerts[0])
+	if err != nil {
 		return CertificateValidationResult{
 			Valid: false,
 			Error: fmt.Errorf("invalid SKI format: %w", err),
 		}
 	}
 
-	remoteSKI := fmt.Sprintf("%0x", remoteCerts[0].SubjectKeyId)
 	if remoteSKI != expectedSKI {
 		return CertificateValidationResult{
 			Valid: false,

--- a/hub/hub_connections_client.go
+++ b/hub/hub_connections_client.go
@@ -178,8 +178,7 @@ func (h *Hub) connectFoundService(remoteService *api.ServiceDetails, host, port,
 func (h *Hub) shouldAttemptConnection(remoteService *api.ServiceDetails) bool {
 	// connection attempt is not relevant if the device is no longer paired
 	// or it is not queued for pairing
-	pairingState := h.ServiceForSKI(remoteService.SKI()).ConnectionStateDetail().State()
-	return h.IsRemoteServiceForSKIPaired(remoteService.SKI()) || pairingState == api.ConnectionStateQueued
+	return h.IsRemoteServiceForSKIPaired(remoteService.SKI())
 }
 
 // tryConnectionViaHost attempts connection using hostname
@@ -219,6 +218,10 @@ func (h *Hub) tryConnectionViaAddresses(remoteService *api.ServiceDetails, entry
 // initateConnection attempts to establish a connection to a remote service
 // returns true if successful
 func (h *Hub) initateConnection(remoteService *api.ServiceDetails, entry *api.MdnsEntry) bool {
+	defer func() {
+		h.setConnectionAttemptRunning(remoteService.SKI(), false)
+	}()
+
 	// Check if connection attempt should be made
 	if !h.shouldAttemptConnection(remoteService) {
 		return false

--- a/hub/hub_connections_client.go
+++ b/hub/hub_connections_client.go
@@ -197,17 +197,6 @@ func (h *Hub) tryConnectionViaHost(remoteService *api.ServiceDetails, entry *api
 	return true
 }
 
-// formatIPAddress formats an IP address for connection (handles IPv6 brackets)
-// This is a pure function that's easy to test
-func formatIPAddress(address net.IP) string {
-	if address.To4() == nil {
-		// IPv6
-		return "[" + address.String() + "]"
-	}
-	// IPv4
-	return address.String()
-}
-
 // tryConnectionViaAddresses attempts connection using IP addresses
 // This is a focused function that handles IP-based connection attempts
 func (h *Hub) tryConnectionViaAddresses(remoteService *api.ServiceDetails, entry *api.MdnsEntry) bool {
@@ -217,7 +206,7 @@ func (h *Hub) tryConnectionViaAddresses(remoteService *api.ServiceDetails, entry
 	// try connecting via the provided IP addresses
 	for _, address := range entry.Addresses {
 		logging.Log().Debugf("trying to connect to %s at %s", remoteService.SKI(), address)
-		addressValue := formatIPAddress(address)
+		addressValue := address.String()
 		if err := h.connectFoundService(remoteService, addressValue, strconv.Itoa(entry.Port), entry.Path); err != nil {
 			logConnectionError(err, fmt.Sprintf("connection to %s at %s failed:", remoteService.SKI(), addressValue))
 		} else {

--- a/hub/hub_connections_client_decomposed_test.go
+++ b/hub/hub_connections_client_decomposed_test.go
@@ -170,31 +170,36 @@ func (s *HubConnectionsDecomposedTestSuite) Test_ValidateRemoteCertificate() {
 		{
 			name:        "empty_certificates",
 			certs:       []*x509.Certificate{},
-			expectedSKI: "test-ski",
+			expectedSKI: "testski",
 			expectValid: false,
 			errorMsg:    "no SKI in certificate",
 		},
 		{
 			name:        "nil_subject_key_id",
 			certs:       []*x509.Certificate{createValidationTestCertificate("")},
-			expectedSKI: "test-ski",
+			expectedSKI: "testski",
 			expectValid: false,
 			errorMsg:    "no SKI in certificate",
 		},
-		{
-			name:        "ski_mismatch",
-			certs:       []*x509.Certificate{createValidationTestCertificate("wrong-ski")},
-			expectedSKI: "746573742d736b69000000000000000000000000", // hex of proper 20-byte SKI
-			expectValid: false,
-			errorMsg:    "SKI mismatch",
-		},
-		{
-			name:        "valid_certificate",
-			certs:       []*x509.Certificate{createValidationTestCertificate("746573742d736b69")},
-			expectedSKI: "746573742d736b69000000000000000000000000", // hex of proper 20-byte SKI
-			expectValid: true,
-		},
 	}
+
+	// Create a valid certificate test case using the cert package
+	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "validtestski")
+	validCert, _ := x509.ParseCertificate(certificate.Certificate[0])
+	validSKI, _ := cert.SkiFromCertificate(validCert)
+
+	tests = append(tests, struct {
+		name        string
+		certs       []*x509.Certificate
+		expectedSKI string
+		expectValid bool
+		errorMsg    string
+	}{
+		name:        "valid_certificate_with_correct_ski",
+		certs:       []*x509.Certificate{validCert},
+		expectedSKI: validSKI,
+		expectValid: true,
+	})
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {

--- a/hub/hub_connections_client_decomposed_test.go
+++ b/hub/hub_connections_client_decomposed_test.go
@@ -305,16 +305,6 @@ func (s *HubConnectionsDecomposedTestSuite) Test_ShouldAttemptConnection() {
 			expectAttempt: true,
 		},
 		{
-			name: "queued_service",
-			setupService: func() *api.ServiceDetails {
-				// Use ServiceForSKI which handles normalization and creation
-				service := s.hub.ServiceForSKI("queuedski") // normalized version
-				service.ConnectionStateDetail().SetState(api.ConnectionStateQueued)
-				return service
-			},
-			expectAttempt: true,
-		},
-		{
 			name: "unpaired_unqueued_service",
 			setupService: func() *api.ServiceDetails {
 				// Use ServiceForSKI which handles normalization and creation

--- a/hub/hub_connections_client_decomposed_test.go
+++ b/hub/hub_connections_client_decomposed_test.go
@@ -217,43 +217,6 @@ func (s *HubConnectionsDecomposedTestSuite) Test_ValidateRemoteCertificate() {
 	}
 }
 
-// Test formatIPAddress function
-func (s *HubConnectionsDecomposedTestSuite) Test_FormatIPAddress() {
-	tests := []struct {
-		name     string
-		input    net.IP
-		expected string
-	}{
-		{
-			name:     "ipv4_address",
-			input:    net.ParseIP("192.168.1.1"),
-			expected: "192.168.1.1",
-		},
-		{
-			name:     "ipv6_address",
-			input:    net.ParseIP("2001:db8::1"),
-			expected: "[2001:db8::1]",
-		},
-		{
-			name:     "ipv6_loopback",
-			input:    net.ParseIP("::1"),
-			expected: "[::1]",
-		},
-		{
-			name:     "ipv4_loopback",
-			input:    net.ParseIP("127.0.0.1"),
-			expected: "127.0.0.1",
-		},
-	}
-
-	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			result := formatIPAddress(tt.input)
-			assert.Equal(s.T(), tt.expected, result)
-		})
-	}
-}
-
 // Test sortIPAddresses function
 func (s *HubConnectionsDecomposedTestSuite) Test_SortIPAddresses() {
 	tests := []struct {

--- a/hub/hub_connections_expiration_test.go
+++ b/hub/hub_connections_expiration_test.go
@@ -7,12 +7,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/enbility/ship-go/api"
 	"github.com/enbility/ship-go/cert"
+	"github.com/enbility/ship-go/logging"
 	"github.com/enbility/ship-go/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -50,72 +52,54 @@ func TestCertificateExpirationLogging(t *testing.T) {
 		})
 
 		// Test with expiring certificate
-		t.Run("expiring_certificate", func(t *testing.T) {
-			// Create a certificate that expires in 20 days
-			template := createTestCertificateTemplate("test-expiring", 20*24*time.Hour)
-			certBytes, _, err := createTestCertificate(template)
-			assert.NoError(t, err)
+		t.Run("certificate_expiration_logging_direct", func(t *testing.T) {
+			logger := NewTestLogger()
+			logging.SetLogging(logger)
+			defer logging.SetLogging(nil)
 
-			// For now, just verify it doesn't error
-			// Full logging test would require log capture mechanism
-			rawCerts := [][]byte{certBytes}
-			err = hub.verifyPeerCertificate(rawCerts, nil)
-			assert.NoError(t, err)
-		})
+			certificate := createDirectTestCertificate(time.Now().Add(10*24*time.Hour), "test-device")
+			ski := fmt.Sprintf("%0x", certificate.SubjectKeyId)
 
-		// Test with expired certificate
-		t.Run("expired_certificate", func(t *testing.T) {
-			// Create a certificate that expired 5 days ago
-			template := createTestCertificateTemplate("test-expired", -5*24*time.Hour)
-			certBytes, _, err := createTestCertificate(template)
-			assert.NoError(t, err)
+			cert.LogCertificateExpiration(certificate, ski)
 
-			// For now, just verify it doesn't error (per SHIP spec)
-			// Full logging test would require log capture mechanism
-			rawCerts := [][]byte{certBytes}
-			err = hub.verifyPeerCertificate(rawCerts, nil)
-			assert.NoError(t, err) // Should still pass despite expiration
+			output := logger.GetOutput()
+			assert.Contains(t, output, "expires in 10 days")
 		})
 	})
-
-	// Additional integration tests for connectFoundService and ServeHTTP
-	// would require more complex setup with WebSocket connections
-	// For now, the pattern is established with verifyPeerCertificate
 }
 
-// Helper function to create a test certificate template with custom expiration
-func createTestCertificateTemplate(commonName string, validityDuration time.Duration) *x509.Certificate {
-	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).SetInt64(100000))
-	return &x509.Certificate{
-		SerialNumber: serialNumber,
+func createDirectTestCertificate(expiryTime time.Time, commonName string) *x509.Certificate {
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	ski := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+		0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14}
+
+	if commonName != "" {
+		hash := []byte(commonName)
+		for i := 0; i < len(hash) && i < 4; i++ {
+			ski[19-i] = hash[i]
+		}
+	}
+
+	template := x509.Certificate{
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+		SerialNumber:       big.NewInt(1),
 		Subject: pkix.Name{
-			CommonName: commonName,
+			OrganizationalUnit: []string{"test"},
+			Organization:       []string{"test"},
+			Country:            []string{"DE"},
+			CommonName:         commonName,
 		},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(validityDuration),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		SubjectKeyId: generateTestSKIBytes(),
-	}
-}
-
-// Helper function to create a test certificate
-func createTestCertificate(template *x509.Certificate) ([]byte, interface{}, error) {
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, nil, err
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              expiryTime,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		SubjectKeyId:          ski,
 	}
 
-	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
-	if err != nil {
-		return nil, nil, err
-	}
+	certBytes, _ := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	certificate, _ := x509.ParseCertificate(certBytes)
 
-	return certDER, priv, nil
-}
-
-// Helper function to generate a test SKI
-func generateTestSKIBytes() []byte {
-	ski := make([]byte, 20)
-	rand.Read(ski)
-	return ski
+	return certificate
 }

--- a/hub/hub_connections_registry.go
+++ b/hub/hub_connections_registry.go
@@ -44,15 +44,16 @@ func (h *Hub) keepThisConnection(conn *websocket.Conn, incomingRequest bool, rem
 		return true
 	}
 
-	// Log the double connection scenario for diagnostics
+	// Log the double connection scenario for diagnostics  
 	logging.Log().Debug("double connection detected with remoteSKI", remoteSKI,
 		"incoming", incomingRequest)
 
 	keep := false
+	localSKI := h.localService.SKI()
 	if incomingRequest {
-		keep = remoteSKI > h.localService.SKI()
+		keep = remoteSKI > localSKI
 	} else {
-		keep = h.localService.SKI() > remoteSKI
+		keep = localSKI > remoteSKI
 	}
 
 	if keep {

--- a/hub/hub_connections_retry.go
+++ b/hub/hub_connections_retry.go
@@ -18,12 +18,6 @@ func (h *Hub) coordinateConnectionInitations(ski string, entry *api.MdnsEntry) {
 
 	counter, duration := h.getConnectionInitiationDelayTime(ski)
 
-	service := h.ServiceForSKI(ski)
-	if service.ConnectionStateDetail().State() == api.ConnectionStateQueued {
-		go h.prepareConnectionInitation(ski, counter, entry)
-		return
-	}
-
 	logging.Log().Debugf("delaying connection to %s by %s to minimize double connection probability", ski, duration)
 
 	// Create a cancellable timer
@@ -38,8 +32,6 @@ func (h *Hub) coordinateConnectionInitations(ski string, entry *api.MdnsEntry) {
 // prepareConnectionInitation is invoked by coordinateConnectionInitations either with a delay or directly
 // when initiating a pairing process
 func (h *Hub) prepareConnectionInitation(ski string, counter int, entry *api.MdnsEntry) {
-	h.setConnectionAttemptRunning(ski, false)
-
 	// check if the current counter is still the same, otherwise this counter is irrelevant
 	currentCounter, exists := h.getCurrentConnectionAttemptCounter(ski)
 	if !exists || currentCounter != counter {
@@ -48,8 +40,7 @@ func (h *Hub) prepareConnectionInitation(ski string, counter int, entry *api.Mdn
 
 	// connection attempt is not relevant if the device is no longer paired
 	// or it is not queued for pairing
-	pairingState := h.ServiceForSKI(ski).ConnectionStateDetail().State()
-	if !h.IsRemoteServiceForSKIPaired(ski) && pairingState != api.ConnectionStateQueued {
+	if !h.IsRemoteServiceForSKIPaired(ski) {
 		return
 	}
 

--- a/hub/hub_mdns.go
+++ b/hub/hub_mdns.go
@@ -6,12 +6,16 @@ import (
 	"strings"
 
 	"github.com/enbility/ship-go/api"
+	"github.com/enbility/ship-go/logging"
 )
 
 var _ api.MdnsReportInterface = (*Hub)(nil)
 
 // Process reported mDNS services
 func (h *Hub) ReportMdnsEntries(entries map[string]*api.MdnsEntry, newEntries bool) {
+	// Clean up connection attempts for SKIs that are no longer in mDNS
+	h.cleanupRemovedMdnsEntries(entries)
+
 	var mdnsEntries []*api.MdnsEntry
 
 	for _, entry := range entries {
@@ -73,4 +77,27 @@ func (h *Hub) ReportMdnsEntries(entries map[string]*api.MdnsEntry, newEntries bo
 	}
 
 	h.hubReader.VisibleRemoteServicesUpdated(remoteServices)
+}
+
+// cleanupRemovedMdnsEntries cancels connection attempts for SKIs no longer visible in mDNS
+func (h *Hub) cleanupRemovedMdnsEntries(currentEntries map[string]*api.MdnsEntry) {
+	h.muxMdns.Lock()
+	previousEntries := h.knownMdnsEntries
+	h.muxMdns.Unlock()
+
+	// Create a set of current SKIs for efficient lookup
+	currentSKIs := make(map[string]bool)
+	for _, entry := range currentEntries {
+		currentSKIs[entry.Ski] = true
+	}
+
+	// Check each previous entry to see if it's still present
+	for _, prevEntry := range previousEntries {
+		if !currentSKIs[prevEntry.Ski] {
+			// SKI is no longer in mDNS - cancel connection attempts immediately
+			logging.Log().Debugf("hub: cleaning up connection attempts for SKI %s (no longer in mDNS)", prevEntry.Ski)
+			h.cancelConnectionDelayTimer(prevEntry.Ski)
+			h.removeConnectionAttemptCounter(prevEntry.Ski)
+		}
+	}
 }

--- a/hub/hub_mdns.go
+++ b/hub/hub_mdns.go
@@ -28,8 +28,7 @@ func (h *Hub) ReportMdnsEntries(entries map[string]*api.MdnsEntry, newEntries bo
 
 		// Check if the remote service is paired or queued for connection
 		service := h.ServiceForSKI(entry.Ski)
-		if !h.IsRemoteServiceForSKIPaired(entry.Ski) &&
-			service.ConnectionStateDetail().State() != api.ConnectionStateQueued {
+		if !h.IsRemoteServiceForSKIPaired(entry.Ski) {
 			continue
 		}
 

--- a/hub/hub_mdns.go
+++ b/hub/hub_mdns.go
@@ -14,17 +14,17 @@ var _ api.MdnsReportInterface = (*Hub)(nil)
 func (h *Hub) ReportMdnsEntries(entries map[string]*api.MdnsEntry, newEntries bool) {
 	var mdnsEntries []*api.MdnsEntry
 
-	for ski, entry := range entries {
+	for _, entry := range entries {
 		mdnsEntries = append(mdnsEntries, entry)
 
 		// check if this ski is already connected
-		if h.isSkiConnected(ski) {
+		if h.isSkiConnected(entry.Ski) {
 			continue
 		}
 
 		// Check if the remote service is paired or queued for connection
-		service := h.ServiceForSKI(ski)
-		if !h.IsRemoteServiceForSKIPaired(ski) &&
+		service := h.ServiceForSKI(entry.Ski)
+		if !h.IsRemoteServiceForSKIPaired(entry.Ski) &&
 			service.ConnectionStateDetail().State() != api.ConnectionStateQueued {
 			continue
 		}
@@ -38,7 +38,7 @@ func (h *Hub) ReportMdnsEntries(entries map[string]*api.MdnsEntry, newEntries bo
 			}
 		}
 
-		h.coordinateConnectionInitations(ski, entry)
+		h.coordinateConnectionInitations(entry.Ski, entry)
 	}
 
 	sort.Slice(mdnsEntries, func(i, j int) bool {

--- a/hub/hub_mdns_test.go
+++ b/hub/hub_mdns_test.go
@@ -1,0 +1,164 @@
+package hub
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enbility/ship-go/api"
+	"github.com/enbility/ship-go/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// Test mDNS cleanup functionality when services disappear
+func TestReportMdnsEntries_CleanupRemovedEntries(t *testing.T) {
+	mockMdns := mocks.NewMdnsInterface(t)
+	hub := &Hub{
+		connections:              make(map[string]api.ShipConnectionInterface),
+		remoteServices:           make(map[string]*api.ServiceDetails, 0),
+		connectionAttemptCounter: make(map[string]int),
+		connectionAttemptRunning: make(map[string]bool),
+		connectionDelayTimers:    make(map[string]*connectionDelayTimer),
+		knownMdnsEntries:         make([]*api.MdnsEntry, 0),
+		muxMdns:                  sync.Mutex{},
+		muxTimers:                sync.RWMutex{},
+		muxConAttempt:            sync.RWMutex{},
+		mdns:                     mockMdns,
+	}
+
+	mockHubReader := mocks.NewHubReaderInterface(t)
+	mockHubReader.EXPECT().VisibleRemoteServicesUpdated(mock.AnythingOfType("[]api.RemoteService")).Times(3)
+	hub.hubReader = mockHubReader
+
+	// Step 1: Report initial entries with two services
+	ski1, ski2 := "SKI1", "SKI2"
+	initialEntries := map[string]*api.MdnsEntry{
+		"service1": {Name: "Service 1", Ski: ski1, Identifier: "ID1"},
+		"service2": {Name: "Service 2", Ski: ski2, Identifier: "ID2"},
+	}
+
+	// Set up connection attempts for both SKIs
+	hub.connectionAttemptCounter[ski1] = 2
+	hub.connectionAttemptCounter[ski2] = 1
+	// Create proper test timers using the factory method
+	hub.connectionDelayTimers[ski1] = newConnectionDelayTimer(time.Millisecond, func() {})
+	hub.connectionDelayTimers[ski2] = newConnectionDelayTimer(time.Millisecond, func() {})
+
+	hub.ReportMdnsEntries(initialEntries, true)
+
+	// Verify both SKIs have connection state
+	assert.Equal(t, 2, hub.connectionAttemptCounter[ski1])
+	assert.Equal(t, 1, hub.connectionAttemptCounter[ski2])
+	assert.Contains(t, hub.connectionDelayTimers, ski1)
+	assert.Contains(t, hub.connectionDelayTimers, ski2)
+
+	// Step 2: Report entries with only service1 (service2 disappeared)
+	updatedEntries := map[string]*api.MdnsEntry{
+		"service1": {Name: "Service 1", Ski: ski1, Identifier: "ID1"},
+	}
+
+	hub.ReportMdnsEntries(updatedEntries, true)
+
+	// Verify SKI1 state is preserved, SKI2 state is cleaned up
+	assert.Equal(t, 2, hub.connectionAttemptCounter[ski1], "SKI1 connection counter should be preserved")
+	assert.NotContains(t, hub.connectionAttemptCounter, ski2, "SKI2 connection counter should be removed")
+	assert.Contains(t, hub.connectionDelayTimers, ski1, "SKI1 timer should be preserved")
+	assert.NotContains(t, hub.connectionDelayTimers, ski2, "SKI2 timer should be removed")
+
+	// Step 3: Report empty entries (all services disappeared)
+	emptyEntries := map[string]*api.MdnsEntry{}
+
+	hub.ReportMdnsEntries(emptyEntries, true)
+
+	// Verify all connection state is cleaned up
+	assert.NotContains(t, hub.connectionAttemptCounter, ski1, "All connection counters should be removed")
+	assert.NotContains(t, hub.connectionDelayTimers, ski1, "All connection timers should be removed")
+	assert.Len(t, hub.connectionAttemptCounter, 0, "Connection counter map should be empty")
+	assert.Len(t, hub.connectionDelayTimers, 0, "Connection timer map should be empty")
+
+	mockHubReader.AssertExpectations(t)
+}
+
+// Test that cleanup doesn't interfere with normal operation
+func TestReportMdnsEntries_CleanupWithNewEntries(t *testing.T) {
+	mockMdns := mocks.NewMdnsInterface(t)
+	hub := &Hub{
+		connections:              make(map[string]api.ShipConnectionInterface),
+		remoteServices:           make(map[string]*api.ServiceDetails, 0),
+		connectionAttemptCounter: make(map[string]int),
+		connectionAttemptRunning: make(map[string]bool),
+		connectionDelayTimers:    make(map[string]*connectionDelayTimer),
+		knownMdnsEntries:         make([]*api.MdnsEntry, 0),
+		muxMdns:                  sync.Mutex{},
+		muxTimers:                sync.RWMutex{},
+		muxConAttempt:            sync.RWMutex{},
+		mdns:                     mockMdns,
+	}
+
+	mockHubReader := mocks.NewHubReaderInterface(t)
+	mockHubReader.EXPECT().VisibleRemoteServicesUpdated(mock.AnythingOfType("[]api.RemoteService")).Times(2)
+	hub.hubReader = mockHubReader
+
+	// Initial state: service1 and service2
+	initialEntries := map[string]*api.MdnsEntry{
+		"service1": {Name: "Service 1", Ski: "SKI1", Identifier: "ID1"},
+		"service2": {Name: "Service 2", Ski: "SKI2", Identifier: "ID2"},
+	}
+	hub.connectionAttemptCounter["SKI1"] = 1
+	hub.connectionAttemptCounter["SKI2"] = 2
+
+	hub.ReportMdnsEntries(initialEntries, true)
+
+	// Updated state: remove service1, keep service2, add service3
+	updatedEntries := map[string]*api.MdnsEntry{
+		"service2": {Name: "Service 2", Ski: "SKI2", Identifier: "ID2"},
+		"service3": {Name: "Service 3", Ski: "SKI3", Identifier: "ID3"},
+	}
+
+	hub.ReportMdnsEntries(updatedEntries, true)
+
+	// Verify selective cleanup: SKI1 removed, SKI2 preserved, SKI3 is new
+	assert.NotContains(t, hub.connectionAttemptCounter, "SKI1", "SKI1 should be cleaned up")
+	assert.Equal(t, 2, hub.connectionAttemptCounter["SKI2"], "SKI2 should be preserved")
+	// Note: SKI3 won't have connection state since it wasn't in connectionAttemptCounter initially
+
+	mockHubReader.AssertExpectations(t)
+}
+
+// Test edge case: no previous entries
+func TestReportMdnsEntries_CleanupWithNoPreviousEntries(t *testing.T) {
+	mockMdns := mocks.NewMdnsInterface(t)
+	hub := &Hub{
+		connections:              make(map[string]api.ShipConnectionInterface),
+		remoteServices:           make(map[string]*api.ServiceDetails, 0),
+		connectionAttemptCounter: make(map[string]int),
+		connectionAttemptRunning: make(map[string]bool),
+		connectionDelayTimers:    make(map[string]*connectionDelayTimer),
+		knownMdnsEntries:         make([]*api.MdnsEntry, 0), // No previous entries
+		muxMdns:                  sync.Mutex{},
+		muxTimers:                sync.RWMutex{},
+		muxConAttempt:            sync.RWMutex{},
+		mdns:                     mockMdns,
+	}
+
+	mockHubReader := mocks.NewHubReaderInterface(t)
+	mockHubReader.EXPECT().VisibleRemoteServicesUpdated(mock.AnythingOfType("[]api.RemoteService")).Once()
+	hub.hubReader = mockHubReader
+
+	// Add some connection state that shouldn't be affected (since no previous entries)
+	hub.connectionAttemptCounter["SKI1"] = 3
+
+	entries := map[string]*api.MdnsEntry{
+		"service1": {Name: "Service 1", Ski: "SKI1", Identifier: "ID1"},
+	}
+
+	hub.ReportMdnsEntries(entries, true)
+
+	// With no previous entries, no cleanup should occur
+	assert.Equal(t, 3, hub.connectionAttemptCounter["SKI1"], "Existing connection state should be preserved")
+
+	mockHubReader.AssertExpectations(t)
+}
+
+// Create tests the cover ReportMdnsEntries implementation

--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -124,11 +124,6 @@ func (h *Hub) RegisterRemoteSKI(ski, shipID string) {
 		return
 	}
 
-	// locally initiated
-	service.ConnectionStateDetail().SetState(api.ConnectionStateQueued)
-
-	h.hubReader.ServicePairingDetailUpdate(ski, service.ConnectionStateDetail())
-
 	h.mdns.RequestMdnsEntries()
 }
 

--- a/hub/hub_shipconnection.go
+++ b/hub/hub_shipconnection.go
@@ -44,8 +44,6 @@ func (h *Hub) HandleConnectionClosed(connection api.ShipConnectionInterface, han
 
 // report the ship ID provided during the handshake
 func (h *Hub) ReportServiceShipID(ski string, shipdID string) {
-	h.hubReader.RemoteSKIConnected(ski)
-
 	h.hubReader.ServiceShipIDUpdate(ski, shipdID)
 }
 
@@ -81,6 +79,11 @@ func (h *Hub) HandleShipHandshakeStateUpdate(ski string, state model.ShipState) 
 	existingState := existingDetails.State()
 	if existingState != pairingState || !errors.Is(existingDetails.Error(), state.Error) {
 		service.SetConnectionStateDetail(pairingDetail)
+
+		if pairingState == api.ConnectionStateCompleted {
+			// inform the application about a successful connection
+			h.hubReader.RemoteSKIConnected(ski)
+		}
 
 		// always send a delayed update, as the processing of the new state has to be done
 		// and the SHIP message has to be received by the other service before

--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -209,7 +209,7 @@ func (m *MdnsManager) Start(cb api.MdnsReportInterface) error {
 		default:
 			return fmt.Errorf("invalid mDNS provider selection: %d", m.providerSelection)
 		}
-		
+
 		if err != nil {
 			return err
 		}
@@ -246,7 +246,7 @@ func (m *MdnsManager) Start(cb api.MdnsReportInterface) error {
 func (m *MdnsManager) Shutdown() {
 	m.shutdownOnce.Do(func() {
 		logging.Log().Debug("mdns: shutting down mDNS manager")
-		
+
 		// Safely unannounce the service
 		func() {
 			defer func() {
@@ -348,7 +348,7 @@ func (m *MdnsManager) UnannounceMdnsEntry() {
 	if !m.isServiceAnnounced() {
 		return
 	}
-	
+
 	if m.mdnsProvider == nil {
 		return
 	}
@@ -475,30 +475,30 @@ func (m *MdnsManager) copyMdnsEntries() map[string]*api.MdnsEntry {
 	return mdnsEntries
 }
 
-func (m *MdnsManager) mdnsEntry(ski string) (*api.MdnsEntry, bool) {
+func (m *MdnsManager) mdnsEntry(serviceName string) (*api.MdnsEntry, bool) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	entry, ok := m.entries[ski]
+	entry, ok := m.entries[serviceName]
 	return entry, ok
 }
 
-func (m *MdnsManager) setMdnsEntry(ski string, entry *api.MdnsEntry) {
+func (m *MdnsManager) setMdnsEntry(serviceName string, entry *api.MdnsEntry) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	m.entries[ski] = entry
+	m.entries[serviceName] = entry
 }
 
-func (m *MdnsManager) removeMdnsEntry(ski string) {
+func (m *MdnsManager) removeMdnsEntry(serviceName string) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	delete(m.entries, ski)
+	delete(m.entries, serviceName)
 }
 
 // process an mDNS entry and manage mDNS entries map
-func (m *MdnsManager) processMdnsEntry(elements map[string]string, name, host string, addresses []net.IP, port int, remove bool) {
+func (m *MdnsManager) processMdnsEntry(elements map[string]string, serviceName, host string, addresses []net.IP, port int, remove bool) {
 	// check for mandatory text elements
 	mapItems := []string{"txtvers", "id", "path", "ski", "register"}
 	for _, item := range mapItems {
@@ -524,9 +524,12 @@ func (m *MdnsManager) processMdnsEntry(elements map[string]string, name, host st
 		return
 	}
 
+	trueValue := "true"
+	falseValue := "false"
+
 	register := elements["register"]
 	// register has to be a boolean
-	if register != "true" && register != "false" {
+	if register != trueValue && register != falseValue {
 		logging.Log().Debug("mdns: txt - register value is not a text boolean", register)
 		return
 	}
@@ -573,19 +576,50 @@ func (m *MdnsManager) processMdnsEntry(elements map[string]string, name, host st
 
 	updated := false
 
-	entry, exists := m.mdnsEntry(ski)
+	entry, exists := m.mdnsEntry(serviceName)
 
 	if remove && exists {
 		updated = true
 		// remove
 		// there will be a remove for each address with avahi, but we'll delete it right away
-		m.removeMdnsEntry(ski)
+		m.removeMdnsEntry(serviceName)
 
-		logging.Log().Debug("mdns: remove - ski:", ski, "name:", name, "brand:", brand, "model:", model, "typ:", deviceType, "serial:", serial, "categories:", categoriesStr, "identifier:", identifier, "register:", register, "host:", host, "port:", port, "addresses:", addresses)
+		logging.Log().Debug("mdns: remove - ski:", ski, "serviceName:", serviceName, "brand:", brand, "model:", model, "typ:", deviceType, "serial:", serial, "categories:", categoriesStr, "identifier:", identifier, "register:", register, "host:", host, "port:", port, "addresses:", addresses)
 	} else if exists {
-		// avahi sends an item for each network address, merge them
+		// Update existing entry with new metadata and merge addresses
 
-		// we assume only network addresses are added
+		// Update all metadata fields (they may have changed)
+		if entry.Brand != brand || entry.Type != deviceType || entry.Model != model ||
+			entry.Serial != serial || entry.Identifier != identifier ||
+			entry.Path != path || entry.Register != (register == trueValue) ||
+			entry.Host != host || entry.Port != port ||
+			len(entry.Categories) != len(categories) {
+			updated = true
+		}
+
+		// Check if categories changed
+		if !updated && len(entry.Categories) == len(categories) {
+			for i, cat := range entry.Categories {
+				if i >= len(categories) || cat != categories[i] {
+					updated = true
+					break
+				}
+			}
+		}
+
+		// Update metadata
+		entry.Identifier = identifier
+		entry.Path = path
+		entry.Register = register == trueValue
+		entry.Brand = brand
+		entry.Type = deviceType
+		entry.Model = model
+		entry.Serial = serial
+		entry.Categories = categories
+		entry.Host = host
+		entry.Port = port
+
+		// Merge addresses (avahi sends an item for each network address)
 		for _, address := range addresses {
 			// only add if it is not added yet
 			isNewElement := true
@@ -604,15 +638,15 @@ func (m *MdnsManager) processMdnsEntry(elements map[string]string, name, host st
 		}
 
 		if updated {
-			m.setMdnsEntry(ski, entry)
+			m.setMdnsEntry(serviceName, entry)
 
-			logging.Log().Debug("mdns: update - ski:", ski, "name:", name, "brand:", brand, "model:", model, "typ:", deviceType, "serial:", serial, "categories:", categoriesStr, "identifier:", identifier, "register:", register, "host:", host, "port:", port, "addresses:", addresses)
+			logging.Log().Debug("mdns: update - ski:", ski, "serviceName:", serviceName, "brand:", brand, "model:", model, "typ:", deviceType, "serial:", serial, "categories:", categoriesStr, "identifier:", identifier, "register:", register, "host:", host, "port:", port, "addresses:", addresses)
 		}
 	} else if !exists && !remove {
 		updated = true
 		// new
 		newEntry := &api.MdnsEntry{
-			Name:       name,
+			Name:       serviceName,
 			Ski:        ski,
 			Identifier: identifier,
 			Path:       path,
@@ -626,9 +660,9 @@ func (m *MdnsManager) processMdnsEntry(elements map[string]string, name, host st
 			Port:       port,
 			Addresses:  addresses,
 		}
-		m.setMdnsEntry(ski, newEntry)
+		m.setMdnsEntry(serviceName, newEntry)
 
-		logging.Log().Debug("mdns: new - ski:", ski, "name:", name, "brand:", brand, "model:", model, "typ:", deviceType, "serial:", serial, "categories:", categoriesStr, "identifier:", identifier, "register:", register, "host:", host, "port:", port, "addresses:", addresses)
+		logging.Log().Debug("mdns: new - ski:", ski, "serviceName:", serviceName, "brand:", brand, "model:", model, "typ:", deviceType, "serial:", serial, "categories:", categoriesStr, "identifier:", identifier, "register:", register, "host:", host, "port:", port, "addresses:", addresses)
 	}
 
 	if m.report == nil || !updated {
@@ -688,7 +722,7 @@ func (m *MdnsManager) initializeAvahiProvider(ifaceIndexes []int32, autoReconnec
 	return nil
 }
 
-// initializeZeroconfProvider creates and starts a Zeroconf provider  
+// initializeZeroconfProvider creates and starts a Zeroconf provider
 func (m *MdnsManager) initializeZeroconfProvider(ifaces []net.Interface, autoReconnect bool) error {
 	if m.providerFactory.NewZeroconf == nil {
 		return fmt.Errorf("zeroconf provider factory function not available (interfaces: %d)", len(ifaces))

--- a/mdns/mdns_test.go
+++ b/mdns/mdns_test.go
@@ -67,7 +67,7 @@ func (s *MdnsSuite) Test_LongStrings() {
 
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	
+
 	// Verify string truncation works
 	assert.Equal(s.T(), "brandbrandbrandbrandbrandbrandbr", s.sut.deviceBrand)
 	assert.Equal(s.T(), "modelmodelmodelmodelmodelmodelmo", s.sut.deviceModel)
@@ -112,7 +112,7 @@ func (s *MdnsSuite) Test_AvahiOnly() {
 
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	
+
 	// Verify the provider selection is correct
 	assert.Equal(s.T(), MdnsProviderSelectionAvahiOnly, s.sut.providerSelection)
 }
@@ -191,6 +191,7 @@ func (s *MdnsSuite) Test_Shutdown_NoStart() {
 
 func (s *MdnsSuite) Test_MdnsEntry() {
 	testSki := "test"
+	testService := "mdns_service"
 
 	entries := s.sut.mdnsEntries()
 	assert.Equal(s.T(), 0, len(entries))
@@ -199,18 +200,18 @@ func (s *MdnsSuite) Test_MdnsEntry() {
 		Ski: testSki,
 	}
 
-	s.sut.setMdnsEntry(testSki, entry)
+	s.sut.setMdnsEntry(testService, entry)
 	entries = s.sut.mdnsEntries()
 	assert.Equal(s.T(), 1, len(entries))
 
-	theEntry, ok := s.sut.mdnsEntry(testSki)
+	theEntry, ok := s.sut.mdnsEntry(testService)
 	assert.Equal(s.T(), true, ok)
 	assert.NotNil(s.T(), theEntry)
 
 	copyEntries := s.sut.copyMdnsEntries()
 	assert.Equal(s.T(), 1, len(copyEntries))
 
-	s.sut.removeMdnsEntry(testSki)
+	s.sut.removeMdnsEntry(testService)
 	entries = s.sut.mdnsEntries()
 	assert.Equal(s.T(), 0, len(entries))
 	assert.Equal(s.T(), 1, len(copyEntries))
@@ -218,11 +219,12 @@ func (s *MdnsSuite) Test_MdnsEntry() {
 
 func (s *MdnsSuite) Test_MdnsEntries() {
 	testSki := "test"
+	testService := "mdns_service"
 
 	entry := &api.MdnsEntry{
 		Ski: testSki,
 	}
-	s.sut.setMdnsEntry(testSki, entry)
+	s.sut.setMdnsEntry(testService, entry)
 	entries := s.sut.mdnsEntries()
 	assert.Equal(s.T(), 1, len(entries))
 
@@ -302,12 +304,12 @@ func (s *MdnsSuite) Test_SetTestProvider() {
 	mockProvider := s.mdnsProvider
 	mockProvider.On("Announce", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockProvider.On("Unannounce").Return()
-	
+
 	s.sut.SetTestProvider(mockProvider)
-	
+
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	
+
 	// Verify the injected provider is used
 	assert.Equal(s.T(), mockProvider, s.sut.testProvider)
 	assert.Equal(s.T(), mockProvider, s.sut.mdnsProvider)
@@ -323,7 +325,7 @@ func (s *MdnsSuite) Test_ProviderSelection() {
 		{"AvahiOnly", MdnsProviderSelectionAvahiOnly},
 		{"ZeroconfOnly", MdnsProviderSelectionGoZeroConfOnly},
 	}
-	
+
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
 			manager := NewMDNS("test", "brand", "model", "type", "serial",
@@ -337,45 +339,45 @@ func (s *MdnsSuite) Test_ProviderSelection() {
 func (s *MdnsSuite) Test_ProviderFallback_AvahiToZeroconf() {
 	// Test automatic fallback from Avahi to Zeroconf when Avahi fails
 	s.sut.Shutdown()
-	
+
 	// Create manager with MdnsProviderSelectionAll
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
-	
+
 	// Create mock providers
 	failingAvahi := mocks.NewMdnsProviderInterface(s.T())
 	successfulZeroconf := mocks.NewMdnsProviderInterface(s.T())
-	
+
 	// Setup mock expectations
 	failingAvahi.On("Start", false, mock.Anything).Return(false)
 	failingAvahi.On("Shutdown").Return()
-	
+
 	successfulZeroconf.On("Start", false, mock.Anything).Return(true)
 	successfulZeroconf.On("Announce", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	successfulZeroconf.On("Unannounce").Return()
 	successfulZeroconf.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return failingAvahi },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return successfulZeroconf },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should succeed with fallback to Zeroconf
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	
+
 	// Verify Zeroconf provider is used
 	assert.Equal(s.T(), successfulZeroconf, s.sut.mdnsProvider)
-	
+
 	// Verify Avahi was attempted first and shutdown
 	failingAvahi.AssertCalled(s.T(), "Start", false, mock.Anything)
 	failingAvahi.AssertCalled(s.T(), "Shutdown")
-	
+
 	// Verify Zeroconf was used as fallback
 	successfulZeroconf.AssertCalled(s.T(), "Start", false, mock.Anything)
 }
@@ -383,37 +385,37 @@ func (s *MdnsSuite) Test_ProviderFallback_AvahiToZeroconf() {
 func (s *MdnsSuite) Test_ProviderFallback_BothFail() {
 	// Test error when both Avahi and Zeroconf fail
 	s.sut.Shutdown()
-	
+
 	// Create manager with MdnsProviderSelectionAll
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
-	
+
 	// Create failing mock providers
 	failingAvahi := mocks.NewMdnsProviderInterface(s.T())
 	failingZeroconf := mocks.NewMdnsProviderInterface(s.T())
-	
+
 	// Setup mock expectations
 	failingAvahi.On("Start", false, mock.Anything).Return(false)
 	failingAvahi.On("Shutdown").Return()
-	
+
 	failingZeroconf.On("Start", false, mock.Anything).Return(false)
 	failingZeroconf.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return failingAvahi },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return failingZeroconf },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail with appropriate error
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "no mDNS provider available - both Avahi and Zeroconf failed to initialize (interfaces: 0)", err.Error())
-	
+
 	// Verify both providers were attempted
 	failingAvahi.AssertCalled(s.T(), "Start", false, mock.Anything)
 	failingAvahi.AssertCalled(s.T(), "Shutdown")
@@ -423,34 +425,34 @@ func (s *MdnsSuite) Test_ProviderFallback_BothFail() {
 func (s *MdnsSuite) Test_ProviderAvahiOnly_Success() {
 	// Test AvahiOnly selection with successful provider
 	s.sut.Shutdown()
-	
+
 	// Create manager with MdnsProviderSelectionAvahiOnly
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAvahiOnly)
-	
+
 	// Create successful mock provider
 	successfulAvahi := mocks.NewMdnsProviderInterface(s.T())
-	
+
 	// Setup mock expectations
 	successfulAvahi.On("Start", true, mock.Anything).Return(true)
 	successfulAvahi.On("Announce", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	successfulAvahi.On("Unannounce").Return()
 	successfulAvahi.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return successfulAvahi },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return nil }, // Should not be called
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should succeed
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	
+
 	// Verify Avahi provider is used
 	assert.Equal(s.T(), successfulAvahi, s.sut.mdnsProvider)
 	successfulAvahi.AssertCalled(s.T(), "Start", true, mock.Anything)
@@ -459,34 +461,34 @@ func (s *MdnsSuite) Test_ProviderAvahiOnly_Success() {
 func (s *MdnsSuite) Test_ProviderZeroconfOnly_Success() {
 	// Test ZeroconfOnly selection with successful provider
 	s.sut.Shutdown()
-	
+
 	// Create manager with MdnsProviderSelectionGoZeroConfOnly
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionGoZeroConfOnly)
-	
+
 	// Create successful mock provider
 	successfulZeroconf := mocks.NewMdnsProviderInterface(s.T())
-	
+
 	// Setup mock expectations
 	successfulZeroconf.On("Start", true, mock.Anything).Return(true)
 	successfulZeroconf.On("Announce", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	successfulZeroconf.On("Unannounce").Return()
 	successfulZeroconf.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return nil }, // Should not be called
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return successfulZeroconf },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should succeed
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	
+
 	// Verify Zeroconf provider is used
 	assert.Equal(s.T(), successfulZeroconf, s.sut.mdnsProvider)
 	successfulZeroconf.AssertCalled(s.T(), "Start", true, mock.Anything)
@@ -495,14 +497,14 @@ func (s *MdnsSuite) Test_ProviderZeroconfOnly_Success() {
 func (s *MdnsSuite) Test_Start_InterfaceResolutionError() {
 	// Test error handling when interface resolution fails
 	s.sut.Shutdown()
-	
+
 	// Create manager with invalid interface name
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, []string{"nonexistentinterface"}, MdnsProviderSelectionAll)
-	
+
 	// Start should fail due to invalid interface
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
@@ -512,31 +514,31 @@ func (s *MdnsSuite) Test_Start_InterfaceResolutionError() {
 func (s *MdnsSuite) Test_Start_AnnouncementFailure() {
 	// Test error handling when announcement fails during startup
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
-	
+
 	// Create provider that starts successfully but fails to announce
 	successfulProvider := mocks.NewMdnsProviderInterface(s.T())
 	successfulProvider.On("Start", false, mock.Anything).Return(true)
 	successfulProvider.On("Announce", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("announcement failed"))
 	successfulProvider.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return successfulProvider },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return nil },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail due to announcement failure
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "announcement failed", err.Error())
-	
+
 	// Verify provider was started but announcement failed
 	successfulProvider.AssertCalled(s.T(), "Start", false, mock.Anything)
 	successfulProvider.AssertCalled(s.T(), "Announce", mock.Anything, mock.Anything, mock.Anything)
@@ -545,30 +547,30 @@ func (s *MdnsSuite) Test_Start_AnnouncementFailure() {
 func (s *MdnsSuite) Test_ProviderAvahiOnly_Failure() {
 	// Test AvahiOnly selection when provider fails to start
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAvahiOnly)
-	
+
 	// Create failing provider
 	failingAvahi := mocks.NewMdnsProviderInterface(s.T())
 	failingAvahi.On("Start", true, mock.Anything).Return(false)
 	failingAvahi.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return failingAvahi },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return nil },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail because provider fails to start
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "avahi provider failed to start (interfaces: 1, autoReconnect: true)", err.Error())
-	
+
 	// Verify Avahi was attempted
 	failingAvahi.AssertCalled(s.T(), "Start", true, mock.Anything)
 }
@@ -576,30 +578,30 @@ func (s *MdnsSuite) Test_ProviderAvahiOnly_Failure() {
 func (s *MdnsSuite) Test_ProviderZeroconfOnly_Failure() {
 	// Test ZeroconfOnly selection when provider fails to start
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionGoZeroConfOnly)
-	
+
 	// Create failing provider
 	failingZeroconf := mocks.NewMdnsProviderInterface(s.T())
 	failingZeroconf.On("Start", true, mock.Anything).Return(false)
 	failingZeroconf.On("Shutdown").Return()
-	
+
 	// Set custom provider factory
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return nil },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return failingZeroconf },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail because provider fails to start
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "zeroconf provider failed to start (interfaces: 0, autoReconnect: true)", err.Error())
-	
+
 	// Verify Zeroconf was attempted
 	failingZeroconf.AssertCalled(s.T(), "Start", true, mock.Anything)
 }
@@ -607,16 +609,16 @@ func (s *MdnsSuite) Test_ProviderZeroconfOnly_Failure() {
 func (s *MdnsSuite) Test_Start_NilProviderFactory() {
 	// Test error handling when provider factory is nil
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
-	
+
 	// Set factory to nil
 	s.sut.SetProviderFactory(nil)
-	
+
 	// Start should fail with appropriate error
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
@@ -626,16 +628,16 @@ func (s *MdnsSuite) Test_Start_NilProviderFactory() {
 func (s *MdnsSuite) Test_Start_InvalidProviderSelection() {
 	// Test error handling for invalid provider selection
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
-	
+
 	// Set invalid provider selection
 	s.sut.providerSelection = MdnsProviderSelection(999)
-	
+
 	// Start should fail with appropriate error
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
@@ -645,20 +647,20 @@ func (s *MdnsSuite) Test_Start_InvalidProviderSelection() {
 func (s *MdnsSuite) Test_Start_NilProviderCreation() {
 	// Test error handling when provider factory returns nil
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAvahiOnly)
-	
+
 	// Set factory that returns nil
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return nil },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return nil },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail with appropriate error
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
@@ -668,20 +670,20 @@ func (s *MdnsSuite) Test_Start_NilProviderCreation() {
 func (s *MdnsSuite) Test_Start_NilFactoryFunction() {
 	// Test error handling when factory function is nil
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAvahiOnly)
-	
+
 	// Set factory with nil function
 	factory := &ProviderFactory{
 		NewAvahi:    nil,
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return nil },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail with appropriate error
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
@@ -691,29 +693,29 @@ func (s *MdnsSuite) Test_Start_NilFactoryFunction() {
 func (s *MdnsSuite) Test_ImprovedFallbackErrorMessages() {
 	// Test that improved error messages are returned with fallback
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("test", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
-	
+
 	// Create failing providers
 	failingAvahi := mocks.NewMdnsProviderInterface(s.T())
 	failingZeroconf := mocks.NewMdnsProviderInterface(s.T())
-	
+
 	failingAvahi.On("Start", false, mock.Anything).Return(false)
 	failingAvahi.On("Shutdown").Return()
-	
+
 	failingZeroconf.On("Start", false, mock.Anything).Return(false)
 	failingZeroconf.On("Shutdown").Return()
-	
+
 	factory := &ProviderFactory{
 		NewAvahi:    func([]int32) api.MdnsProviderInterface { return failingAvahi },
 		NewZeroconf: func([]net.Interface) api.MdnsProviderInterface { return failingZeroconf },
 	}
 	s.sut.SetProviderFactory(factory)
-	
+
 	// Start should fail with improved error message
 	err := s.sut.Start(s.mdnsSearch)
 	assert.NotNil(s.T(), err)
@@ -724,7 +726,7 @@ func (s *MdnsSuite) Test_AnnounceMdnsEntry_ValidationErrors() {
 	// Test validation errors in AnnounceMdnsEntry
 	validProvider := mocks.NewMdnsProviderInterface(s.T())
 	validProvider.On("Shutdown").Return()
-	
+
 	// Test empty identifier
 	s.sut.Shutdown()
 	s.sut = NewMDNS("", "brand", "model", "EnergyManagementSystem",
@@ -733,11 +735,11 @@ func (s *MdnsSuite) Test_AnnounceMdnsEntry_ValidationErrors() {
 		"", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
 	s.sut.mdnsProvider = validProvider // Set provider directly to bypass provider check
-	
+
 	err := s.sut.AnnounceMdnsEntry()
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "service identifier is empty")
-	
+
 	// Test empty SKI
 	s.sut = NewMDNS("", "brand", "model", "EnergyManagementSystem",
 		"12345",
@@ -745,11 +747,11 @@ func (s *MdnsSuite) Test_AnnounceMdnsEntry_ValidationErrors() {
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
 	s.sut.mdnsProvider = validProvider
-	
+
 	err = s.sut.AnnounceMdnsEntry()
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "SKI is empty")
-	
+
 	// Test empty service name
 	s.sut = NewMDNS("testski", "brand", "model", "EnergyManagementSystem",
 		"12345",
@@ -757,11 +759,11 @@ func (s *MdnsSuite) Test_AnnounceMdnsEntry_ValidationErrors() {
 		"shipid", "",
 		4729, nil, MdnsProviderSelectionAll)
 	s.sut.mdnsProvider = validProvider
-	
+
 	err = s.sut.AnnounceMdnsEntry()
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "service name is empty")
-	
+
 	// Test invalid port
 	s.sut = NewMDNS("testski", "brand", "model", "EnergyManagementSystem",
 		"12345",
@@ -769,7 +771,7 @@ func (s *MdnsSuite) Test_AnnounceMdnsEntry_ValidationErrors() {
 		"shipid", "serviceName",
 		0, nil, MdnsProviderSelectionAll)
 	s.sut.mdnsProvider = validProvider
-	
+
 	err = s.sut.AnnounceMdnsEntry()
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "invalid port")
@@ -778,14 +780,14 @@ func (s *MdnsSuite) Test_AnnounceMdnsEntry_ValidationErrors() {
 func (s *MdnsSuite) Test_AnnounceMdnsEntry_NoProvider() {
 	// Test announcement when no provider is available
 	s.sut.Shutdown()
-	
+
 	s.sut = NewMDNS("testski", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
 	// Don't set any provider
-	
+
 	err := s.sut.AnnounceMdnsEntry()
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "cannot announce mDNS entry: no provider available (selection: 0)", err.Error())
@@ -800,24 +802,24 @@ func (s *MdnsSuite) Test_Shutdown_DefensiveProgramming() {
 	validProvider.On("Shutdown").Maybe().Run(func(args mock.Arguments) {
 		panic("test panic in shutdown")
 	})
-	
+
 	manager := NewMDNS("testski", "brand", "model", "EnergyManagementSystem",
 		"12345",
 		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
 		"shipid", "serviceName",
 		4729, nil, MdnsProviderSelectionAll)
 	manager.SetTestProvider(validProvider)
-	
+
 	// Set service as announced directly for testing
 	manager.muxAnnounced.Lock()
 	manager.isAnnounced = true
 	manager.muxAnnounced.Unlock()
-	
+
 	// Shutdown should not panic even if provider methods panic
 	assert.NotPanics(s.T(), func() {
 		manager.Shutdown()
 	})
-	
+
 	// Verify provider is cleaned up (defensive shutdown succeeded)
 	assert.Nil(s.T(), manager.mdnsProvider)
 }

--- a/ship/connection_lifecycle.go
+++ b/ship/connection_lifecycle.go
@@ -92,9 +92,8 @@ func (c *ShipConnection) CloseConnection(safe bool, code int, reason string) {
 
 			go func() {
 				// wait a bit to let it send
-				<-time.After(500 * time.Millisecond)
+				<-time.After(100 * time.Millisecond)
 
-				//
 				c.dataWriter.CloseDataConnection(4001, "close")
 				c.infoProvider.HandleConnectionClosed(c, handshakeEnd)
 			}()


### PR DESCRIPTION
- security: fix SKI validation & add fingerprint
  - Calculate SKI from public key using ECDH conversion method
  - Validate certificate SKI matches cryptographically derived value
  - Prevent certificate forgery attacks via SKI field manipulation
  - Ensure RFC 3280 4.2.1.2 method (1) compliance for SHIP protocol
  - Add error case tests
  - Add fingerprint, needed for future functionality
- Fix mDNS incorrect entry merges
  - Do not merge mDNS services with the same SKI into a single one. This would only happen if there would be multiiple mDNS entries claiming the same SKI.
- Fix IPv6 address format
  - The address is already properly formatted for IPv6 using net.JoinHostPort(), so there is no need to do this manually.
- Fix RemoteSKIConnected not being invoked properly 
  - The issue happened, when the service was registered with a known shipid
- When mDNS entries are removed, stop trying to connect to these services
- Fix: eliminate connection race conditions from bypass logic