### PR TITLE
Fix Hub lifecycle bugs: double-start guard and restart panic

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -20,6 +20,12 @@ var (
 	ErrBufferFull = errors.New("buffer full")
 )
 
+// Hub lifecycle errors
+var (
+	// ErrHubAlreadyStarted indicates Start() was called on an already-running Hub
+	ErrHubAlreadyStarted = errors.New("hub already started")
+)
+
 // Certificate and authentication errors
 var (
 	// ErrInvalidCertificate indicates certificate validation failed

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -109,6 +109,14 @@ func (h *Hub) Start() error {
 	h.muxStarted.Lock()
 	defer h.muxStarted.Unlock()
 
+	if h.hasStarted {
+		return fmt.Errorf("%w: call Shutdown() before restarting", api.ErrHubAlreadyStarted)
+	}
+
+	// Reset server state for a fresh start or retry after a previous failure
+	h.serverStarted = make(chan struct{})
+	h.serverStartErr = nil
+
 	// start the websocket server
 	if err := h.startWebsocketServer(); err != nil {
 		return fmt.Errorf("failed to start hub: %w", err)
@@ -203,6 +211,13 @@ func (h *Hub) Shutdown() {
 	case <-time.After(3 * time.Second):
 		logging.Log().Error("timeout waiting for connections to close")
 	}
+
+	// Reset lifecycle state so the Hub can be restarted
+	h.muxStarted.Lock()
+	h.hasStarted = false
+	h.serverStarted = make(chan struct{})
+	h.serverStartErr = nil
+	h.muxStarted.Unlock()
 }
 
 // return the service for a SKI

--- a/hub/hub_connections_server.go
+++ b/hub/hub_connections_server.go
@@ -66,13 +66,14 @@ func (h *Hub) startWebsocketServer() error {
 		},
 	}
 
+	serverStarted := h.serverStarted // capture for goroutine; prevents closing a replaced channel
 	go func() {
 		err := h.httpServer.ListenAndServeTLS("", "")
 		if err != nil && err != http.ErrServerClosed {
 			logging.Log().Error("websocket server error:", err)
 			h.serverStartErr = err
 		}
-		close(h.serverStarted)
+		close(serverStarted)
 	}()
 
 	return nil

--- a/hub/hub_lifecycle_test.go
+++ b/hub/hub_lifecycle_test.go
@@ -1,0 +1,164 @@
+package hub
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/enbility/ship-go/api"
+	"github.com/enbility/ship-go/cert"
+	"github.com/enbility/ship-go/mocks"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// Phase 1 (Red): These tests demonstrate two lifecycle bugs in Hub:
+//
+// Bug 1: Start() has no duplicate guard -- calling Start() twice launches
+//         a second HTTP server goroutine instead of returning an error.
+//
+// Bug 2: Start() after Shutdown() panics -- the serverStarted channel
+//         (created once in NewHub) is closed by the server goroutine on exit.
+//         A second Start() call launches a new goroutine that calls close()
+//         on the already-closed channel, causing a panic.
+//         Additionally, Shutdown() never resets hasStarted or serverStarted.
+
+// TestHub_Lifecycle_DoubleStart_ReturnsError verifies that calling Start()
+// on an already-running Hub returns ErrHubAlreadyStarted.
+func TestHub_Lifecycle_DoubleStart_ReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	hubReader := mocks.NewMockHubReaderInterface(ctrl)
+	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().Start(gomock.Any()).Return(nil).Times(1)
+
+	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
+	localService := api.NewServiceDetails("localSKI")
+
+	hub := NewHub(hubReader, mdnsService, 0, certificate, localService)
+
+	// First start should succeed
+	err := hub.Start()
+	assert.NoError(t, err, "First Start() should succeed")
+	assert.True(t, hub.hasStarted)
+
+	// Second start on the same running Hub must return an error
+	err = hub.Start()
+	assert.Error(t, err, "Second Start() should return an error")
+	assert.ErrorIs(t, err, api.ErrHubAlreadyStarted,
+		"Second Start() should return ErrHubAlreadyStarted")
+
+	// Cleanup
+	mdnsService.EXPECT().Shutdown()
+	hub.Shutdown()
+}
+
+// TestHub_Lifecycle_RestartAfterShutdown verifies that a Hub can be
+// stopped and started again without panicking.
+//
+// Current behavior: panics with "close of closed channel" because
+// serverStarted is created once in NewHub() and never reset.
+func TestHub_Lifecycle_RestartAfterShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	hubReader := mocks.NewMockHubReaderInterface(ctrl)
+	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().Start(gomock.Any()).Return(nil).Times(2)
+	mdnsService.EXPECT().Shutdown().Times(2)
+
+	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
+	localService := api.NewServiceDetails("localSKI")
+
+	hub := NewHub(hubReader, mdnsService, 0, certificate, localService)
+
+	// First lifecycle: start then shutdown
+	err := hub.Start()
+	assert.NoError(t, err, "First Start() should succeed")
+	assert.True(t, hub.hasStarted)
+
+	hub.Shutdown()
+
+	// Second lifecycle: start again -- must not panic
+	assert.NotPanics(t, func() {
+		err = hub.Start()
+	}, "Start() after Shutdown() must not panic")
+	assert.NoError(t, err, "Restart should succeed")
+	assert.True(t, hub.hasStarted)
+
+	// Clean up second lifecycle
+	hub.Shutdown()
+}
+
+// TestHub_Lifecycle_ShutdownResetsState verifies that Shutdown() resets
+// the hasStarted flag so the Hub can be restarted.
+//
+// Current behavior: hasStarted stays true forever after first Start().
+func TestHub_Lifecycle_ShutdownResetsState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	hubReader := mocks.NewMockHubReaderInterface(ctrl)
+	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().Start(gomock.Any()).Return(nil).Times(1)
+	mdnsService.EXPECT().Shutdown().Times(1)
+
+	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
+	localService := api.NewServiceDetails("localSKI")
+
+	hub := NewHub(hubReader, mdnsService, 0, certificate, localService)
+
+	err := hub.Start()
+	assert.NoError(t, err)
+	assert.True(t, hub.hasStarted, "hasStarted should be true after Start()")
+
+	hub.Shutdown()
+	assert.False(t, hub.hasStarted, "hasStarted should be false after Shutdown()")
+}
+
+// TestHub_Lifecycle_RetryAfterMdnsFailure verifies that Start() can be
+// retried on the same Hub instance after a partial failure (server started
+// but mDNS failed).
+//
+// Current behavior: the serverStarted channel is closed by the first
+// attempt's server goroutine. On retry, the select reads from the
+// closed channel immediately (wrong), and the new server goroutine
+// panics when it tries to close it again.
+func TestHub_Lifecycle_RetryAfterMdnsFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	hubReader := mocks.NewMockHubReaderInterface(ctrl)
+	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+
+	// First call fails, second succeeds
+	gomock.InOrder(
+		mdnsService.EXPECT().Start(gomock.Any()).Return(errors.New("mDNS failed")),
+		mdnsService.EXPECT().Start(gomock.Any()).Return(nil),
+	)
+
+	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
+	localService := api.NewServiceDetails("localSKI")
+
+	hub := NewHub(hubReader, mdnsService, 0, certificate, localService)
+
+	// First start fails on mDNS (server starts then gets shut down)
+	err := hub.Start()
+	assert.Error(t, err, "First Start() should fail due to mDNS")
+	assert.False(t, hub.hasStarted, "Hub should not be marked as started")
+
+	// Wait for server goroutine to exit and close the channel
+	time.Sleep(200 * time.Millisecond)
+
+	// Retry should succeed without panic
+	assert.NotPanics(t, func() {
+		err = hub.Start()
+	}, "Retry after mDNS failure must not panic")
+	assert.NoError(t, err, "Retry should succeed")
+	assert.True(t, hub.hasStarted)
+
+	// Cleanup
+	mdnsService.EXPECT().Shutdown()
+	hub.Shutdown()
+}


### PR DESCRIPTION
- Add duplicate-start guard in Hub.Start() returning ErrHubAlreadyStarted
- Reset lifecycle state (hasStarted, serverStarted, serverStartErr) in Shutdown()
- Capture serverStarted channel in goroutine to prevent closing a replaced channel
- Add lifecycle tests covering double-start, restart, shutdown state reset, and retry after failure