### PR TITLE
Disable TLS session resumption to prevent trust bypass (#71)

### DIFF
--- a/hub/hub_connections_server.go
+++ b/hub/hub_connections_server.go
@@ -59,10 +59,11 @@ func (h *Hub) startWebsocketServer() error {
 		ReadHeaderTimeout: time.Duration(time.Second * 10),
 		TLSConfig: &tls.Config{
 			Certificates:          []tls.Certificate{h.certifciate},
-			ClientAuth:            tls.RequireAnyClientCert, // SHIP 9: Client authentication is required
-			CipherSuites:          cert.CipherSuites,        // #nosec G402 // SHIP 9.1: the ciphers are reported insecure but are defined to be used by SHIP
+			ClientAuth:            tls.RequireAnyClientCert,  // SHIP 9: Client authentication is required
+			CipherSuites:          cert.CipherSuites,         // #nosec G402 // SHIP 9.1: the ciphers are reported insecure but are defined to be used by SHIP
 			VerifyPeerCertificate: h.verifyPeerCertificate,
-			MinVersion:            tls.VersionTLS12, // SHIP 9: Mandatory TLS version
+			MinVersion:            tls.VersionTLS12,          // SHIP 9: Mandatory TLS version
+			SessionTicketsDisabled: true,                     // SHIP 9.6: Disable session resumption to prevent bypassing VerifyPeerCertificate
 		},
 	}
 

--- a/hub/hub_connections_server_test.go
+++ b/hub/hub_connections_server_test.go
@@ -184,6 +184,19 @@ func (s *HubConnectionsServerSuite) Test_ServeHTTP_02() {
 	time.Sleep(time.Second)
 }
 
+// Test that TLS session resumption is disabled on the server (SHIP issue #71).
+// Session tickets must be disabled to prevent resumed TLS sessions from
+// bypassing the VerifyPeerCertificate callback after trust has been removed.
+func (s *HubConnectionsServerSuite) Test_TLSSessionResumptionDisabled() {
+	err := s.sut.startWebsocketServer()
+	assert.Nil(s.T(), err)
+
+	tlsConfig := s.sut.httpServer.TLSConfig
+	assert.NotNil(s.T(), tlsConfig)
+	assert.True(s.T(), tlsConfig.SessionTicketsDisabled,
+		"TLS session tickets must be disabled to prevent bypassing certificate verification on resumed sessions")
+}
+
 func (s *HubConnectionsServerSuite) Test_VerifyPeerCertificate() {
 	testCert, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
 	var rawCerts [][]byte


### PR DESCRIPTION
Resumed TLS sessions skip VerifyPeerCertificate, allowing a device whose trust was removed to re-establish a TLS connection via a cached session ticket. Disable session tickets on the server per SHIP 9.6 (session resumption is optional).

Fixes https://github.com/enbility/ship-go/issues/71