### PR TITLE
bug: Avahi dead lock

### DIFF
--- a/hub/deadlock_detection_test.go
+++ b/hub/deadlock_detection_test.go
@@ -405,7 +405,11 @@ func TestSetAutoAccept_DoesNotBlockServiceForSKI(t *testing.T) {
 
 	// Goroutine 1: call Hub.SetAutoAccept — acquires muxReg, then blocks
 	// inside the mock's SetAutoAccept (simulating slow I/O).
-	go hub.SetAutoAccept(true)
+	setAutoAcceptDone := make(chan struct{})
+	go func() {
+		hub.SetAutoAccept(true)
+		close(setAutoAcceptDone)
+	}()
 
 	// Give goroutine 1 a moment to acquire the lock and enter the mock.
 	time.Sleep(20 * time.Millisecond)
@@ -424,8 +428,10 @@ func TestSetAutoAccept_DoesNotBlockServiceForSKI(t *testing.T) {
 		t.Fatal("ServiceForSKI blocked for >500ms — muxReg is held during mDNS SetAutoAccept I/O")
 	}
 
-	// Release the blocked goroutine so the test can clean up.
+	// Release the blocked goroutine and wait for it to finish,
+	// so testify's mock cleanup doesn't race with the in-flight call.
 	close(block)
+	<-setAutoAcceptDone
 }
 
 // TestSetAutoAccept_DoesNotBlockIsAutoAcceptEnabled is a variant that checks
@@ -445,7 +451,11 @@ func TestSetAutoAccept_DoesNotBlockIsAutoAcceptEnabled(t *testing.T) {
 
 	hub.mdns = mdnsMock
 
-	go hub.SetAutoAccept(true)
+	setAutoAcceptDone := make(chan struct{})
+	go func() {
+		hub.SetAutoAccept(true)
+		close(setAutoAcceptDone)
+	}()
 	time.Sleep(20 * time.Millisecond)
 
 	done := make(chan struct{})
@@ -461,5 +471,8 @@ func TestSetAutoAccept_DoesNotBlockIsAutoAcceptEnabled(t *testing.T) {
 		t.Fatal("IsAutoAcceptEnabled blocked for >500ms — muxReg is held during mDNS SetAutoAccept I/O")
 	}
 
+	// Release the blocked goroutine and wait for it to finish,
+	// so testify's mock cleanup doesn't race with the in-flight call.
 	close(block)
+	<-setAutoAcceptDone
 }

--- a/hub/deadlock_detection_test.go
+++ b/hub/deadlock_detection_test.go
@@ -373,3 +373,93 @@ func TestHubStressWithAllOperations(t *testing.T) {
 
 	assert.Less(t, contentionRate, 0.01, "High contention rate detected: %.2f%%", contentionRate*100)
 }
+
+// TestSetAutoAccept_DoesNotBlockServiceForSKI reproduces the stall described
+// in auto-connect-issue.md: Hub.SetAutoAccept holds muxReg (write lock)
+// while calling h.mdns.SetAutoAccept, which may perform slow network I/O
+// (DBus / zeroconf). Any concurrent caller of ServiceForSKI (or any other
+// muxReg consumer) is blocked for the entire duration of that I/O.
+//
+// The test injects a mock MdnsInterface whose SetAutoAccept blocks on a
+// channel, simulating a slow provider. A second goroutine attempts
+// ServiceForSKI. If muxReg is still held during the mDNS call,
+// ServiceForSKI cannot proceed and the test times out — exposing the bug.
+//
+// EXPECTED (current code): FAIL — timeout, ServiceForSKI blocked.
+// EXPECTED (after fix):    PASS — ServiceForSKI completes immediately.
+func TestSetAutoAccept_DoesNotBlockServiceForSKI(t *testing.T) {
+	hub := setupTestHub(t)
+
+	// Channel that keeps the mock's SetAutoAccept blocked until we close it,
+	// simulating a slow mDNS provider (avahi DBus / zeroconf shutdown).
+	block := make(chan struct{})
+
+	mdnsMock := mocks.NewMdnsInterface(t)
+	mdnsMock.EXPECT().SetAutoAccept(mock.Anything).
+		Run(func(_ bool) {
+			<-block // block until test releases
+		}).Return()
+
+	// Replace the hub's mDNS with our blocking mock.
+	hub.mdns = mdnsMock
+
+	// Goroutine 1: call Hub.SetAutoAccept — acquires muxReg, then blocks
+	// inside the mock's SetAutoAccept (simulating slow I/O).
+	go hub.SetAutoAccept(true)
+
+	// Give goroutine 1 a moment to acquire the lock and enter the mock.
+	time.Sleep(20 * time.Millisecond)
+
+	// Goroutine 2: try ServiceForSKI, which also needs muxReg.
+	done := make(chan struct{})
+	go func() {
+		_ = hub.ServiceForSKI("some-ski")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// PASS: ServiceForSKI was not blocked by the mDNS call.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("ServiceForSKI blocked for >500ms — muxReg is held during mDNS SetAutoAccept I/O")
+	}
+
+	// Release the blocked goroutine so the test can clean up.
+	close(block)
+}
+
+// TestSetAutoAccept_DoesNotBlockIsAutoAcceptEnabled is a variant that checks
+// read-lock consumers of muxReg are also not starved. IsAutoAcceptEnabled
+// takes muxReg.RLock — if a write lock is held by SetAutoAccept during mDNS
+// I/O, readers are blocked too.
+func TestSetAutoAccept_DoesNotBlockIsAutoAcceptEnabled(t *testing.T) {
+	hub := setupTestHub(t)
+
+	block := make(chan struct{})
+
+	mdnsMock := mocks.NewMdnsInterface(t)
+	mdnsMock.EXPECT().SetAutoAccept(mock.Anything).
+		Run(func(_ bool) {
+			<-block
+		}).Return()
+
+	hub.mdns = mdnsMock
+
+	go hub.SetAutoAccept(true)
+	time.Sleep(20 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		_ = hub.IsAutoAcceptEnabled()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// PASS
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("IsAutoAcceptEnabled blocked for >500ms — muxReg is held during mDNS SetAutoAccept I/O")
+	}
+
+	close(block)
+}

--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -66,9 +66,8 @@ func (h *Hub) mapShipMessageExchangeState(state model.ShipMessageExchangeState, 
 
 func (h *Hub) SetAutoAccept(autoaccept bool) {
 	h.muxReg.Lock()
-	defer h.muxReg.Unlock()
-
 	h.autoaccept = autoaccept
+	h.muxReg.Unlock()
 
 	h.mdns.SetAutoAccept(autoaccept)
 }

--- a/mdns/avahi.go
+++ b/mdns/avahi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"slices"
 	"sync"
 	"time"
 
@@ -43,9 +44,10 @@ type AvahiProvider struct {
 	shutdownChan                      chan struct{}
 	addServiceChan, removeServiceChan chan avahi.Service
 
-	mux   sync.Mutex
-	muxEl sync.RWMutex // used for serviceElements
-	
+	mux          sync.Mutex
+	announceMux  sync.Mutex   // serializes Announce calls and excludes Shutdown's teardown phase
+	muxEl        sync.RWMutex // used for serviceElements
+
 	// Prevent multiple reconnection goroutines
 	reconnectInProgress bool
 	reconnectMux        sync.Mutex
@@ -196,8 +198,15 @@ func (a *AvahiProvider) Shutdown() {
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	// Wait for any in-flight Announce to finish before tearing down the
+	// server. Without this, an Announce that already passed its snapshot
+	// phase could re-acquire a.mux after Unannounce and store a zombie
+	// entry group referencing the shut-down server.
+	a.announceMux.Lock()
+	defer a.announceMux.Unlock()
+
 	// Unannounce the service
-	a.Unannounce()
+	a.unannounce()
 
 	a.mux.Lock()
 	defer a.mux.Unlock()
@@ -207,67 +216,129 @@ func (a *AvahiProvider) Shutdown() {
 }
 
 func (a *AvahiProvider) Announce(serviceName string, port int, txt []string) error {
-	a.mux.Lock()
-
 	logging.Log().Debug("mdns: using avahi")
+
+	// Serialize concurrent Announce calls so that only one entry group
+	// is created and committed at a time. Without this, two concurrent
+	// callers could each commit a group on the Avahi daemon and then
+	// race to update struct state, orphaning the loser's group.
+	a.announceMux.Lock()
+	defer a.announceMux.Unlock()
 
 	var btxt [][]byte
 	for _, t := range txt {
 		btxt = append(btxt, []byte(t))
 	}
 
-	newEntryGroup, err := a.avServer.EntryGroupNew()
-	if err != nil {
-		a.mux.Unlock()
-		return err
-	}
-
-	// We already hold a.mux lock, so access ifaceIndexes directly
-	for _, iface := range a.ifaceIndexes {
-		// conversion is safe, as port values are always positive
-		err = newEntryGroup.AddService(iface, avahi.ProtoUnspec, 0, serviceName, shipZeroConfServiceType, shipZeroConfDomain, "", uint16(port), btxt) // #nosec G115
-		if err != nil {
+	// Compare-and-retry loop: snapshot ifaceIndexes, perform DBus calls
+	// without holding a.mux (to avoid deadlock with chanListener), then
+	// verify the snapshot is still current. If interfaces changed during
+	// the DBus phase, discard the work and retry once with fresh data.
+	// The announceMux guarantees no external Announce can interleave, so
+	// a single retry suffices — further changes are left to the existing
+	// reannounceWithNewInterfaces mechanism.
+	for attempt := 0; ; attempt++ {
+		// Snapshot ifaceIndexes under the lock, then release immediately.
+		// DBus calls must not execute while holding a.mux: chanListener
+		// (the goroutine that consumes the DBus signal stream delivering
+		// replies to these calls) needs a.mux via processService →
+		// getIfaceIndexes. Holding a.mux across a DBus round-trip blocks
+		// chanListener, preventing the reply from arriving — hard deadlock.
+		a.mux.Lock()
+		if a.manualShutdown {
 			a.mux.Unlock()
+			return fmt.Errorf("mdns: avahi provider is shut down")
+		}
+		ifaceIndexes := make([]int32, len(a.ifaceIndexes))
+		copy(ifaceIndexes, a.ifaceIndexes)
+		a.mux.Unlock()
+
+		// All DBus calls happen without holding a.mux.
+		newEntryGroup, err := a.avServer.EntryGroupNew()
+		if err != nil {
+			return err
+		}
+
+		for _, iface := range ifaceIndexes {
+			// conversion is safe, as port values are always positive
+			err = newEntryGroup.AddService(iface, avahi.ProtoUnspec, 0, serviceName, shipZeroConfServiceType, shipZeroConfDomain, "", uint16(port), btxt) // #nosec G115
+			if err != nil {
+				a.avServer.EntryGroupFree(newEntryGroup)
+				return err
+			}
+		}
+
+		err = newEntryGroup.Commit()
+		if err != nil {
 			a.avServer.EntryGroupFree(newEntryGroup)
 			return err
 		}
-	}
 
-	err = newEntryGroup.Commit()
-	if err != nil {
+		// Re-acquire the lock to update struct state only.
+		// Only store the data for reconnection after a successful commit,
+		// so avahiCallback never re-announces with parameters that were
+		// never successfully committed.
+		a.mux.Lock()
+
+		// Shutdown may have set manualShutdown while we were performing
+		// DBus calls without holding a.mux. Shutdown is blocked on
+		// announceMux so the server is still alive, but storing a new
+		// entry group is pointless — Shutdown's unannounce will free it
+		// immediately. Short-circuit here to avoid the unnecessary state
+		// mutation.
+		if a.manualShutdown {
+			a.mux.Unlock()
+			a.avServer.EntryGroupFree(newEntryGroup)
+			return fmt.Errorf("mdns: avahi provider is shut down")
+		}
+
+		// Only retry once to avoid infinite loops under interface churn.
+		// On the second attempt we proceed regardless — the MdnsManager's
+		// reannounceWithNewInterfaces cycle will reconcile any further drift.
+		if attempt < 1 && !slices.Equal(ifaceIndexes, a.ifaceIndexes) {
+			// Interfaces changed during DBus calls; discard and retry once
+			// with fresh data.
+			a.mux.Unlock()
+			a.avServer.EntryGroupFree(newEntryGroup)
+			continue
+		}
+
+		a.mdnsServiceData = &mdnsServiceData{
+			Name: serviceName,
+			Port: port,
+			Txt:  txt,
+		}
+
+		// Free the old entry group AFTER the new one is committed.
+		// This avoids a window where the service is completely unannounced,
+		// which would cause remote devices to think we left the network.
+		oldEntryGroup := a.avEntryGroup
+		a.avEntryGroup = newEntryGroup
+
 		a.mux.Unlock()
-		a.avServer.EntryGroupFree(newEntryGroup)
-		return err
+
+		if oldEntryGroup != nil {
+			a.avServer.EntryGroupFree(oldEntryGroup)
+		}
+
+		return nil
 	}
-
-	// Only store the data for reconnection after a successful commit,
-	// so avahiCallback never re-announces with parameters that were
-	// never successfully committed.
-	a.mdnsServiceData = &mdnsServiceData{
-		Name: serviceName,
-		Port: port,
-		Txt:  txt,
-	}
-
-	// Free the old entry group AFTER the new one is committed.
-	// This avoids a window where the service is completely unannounced,
-	// which would cause remote devices to think we left the network.
-	oldEntryGroup := a.avEntryGroup
-	a.avEntryGroup = newEntryGroup
-
-	// Release the lock before freeing the old entry group, as
-	// EntryGroupFree may block on dBUS and we don't want to hold
-	// the mutex during that time.
-	a.mux.Unlock()
-
-	if oldEntryGroup != nil {
-		a.avServer.EntryGroupFree(oldEntryGroup)
-	}
-
-	return nil
 }
 
 func (a *AvahiProvider) Unannounce() {
+	// Serialize with Announce so we don't race its DBus phase.
+	// Without this, Unannounce can clear avEntryGroup while Announce
+	// is between Commit and storing the new group — the caller
+	// thinks the service is unannounced, but Announce re-stores it.
+	a.announceMux.Lock()
+	defer a.announceMux.Unlock()
+	a.unannounce()
+}
+
+// unannounce does the actual work without acquiring announceMux.
+// Called by Unannounce (which holds announceMux) and Shutdown
+// (which also holds announceMux).
+func (a *AvahiProvider) unannounce() {
 	a.mux.Lock()
 
 	// clean up the reconnection data

--- a/mdns/avahi.go
+++ b/mdns/avahi.go
@@ -302,6 +302,9 @@ func (a *AvahiProvider) Announce(serviceName string, port int, txt []string) err
 	oldEntryGroup := a.avEntryGroup
 	a.avEntryGroup = newEntryGroup
 
+	// Release the lock before freeing the old entry group, as
+	// EntryGroupFree may block on dBUS and we don't want to hold
+	// the mutex during that time.
 	a.mux.Unlock()
 
 	if oldEntryGroup != nil {

--- a/mdns/avahi.go
+++ b/mdns/avahi.go
@@ -229,12 +229,12 @@ func (a *AvahiProvider) Announce(serviceName string, port int, txt []string) err
 		btxt = append(btxt, []byte(t))
 	}
 
-	// Snapshot ifaceIndexes under the lock, then release immediately.
-	// DBus calls must not execute while holding a.mux: chanListener
-	// (the goroutine that consumes the DBus signal stream delivering
-	// replies to these calls) needs a.mux via processService →
-	// getIfaceIndexes. Holding a.mux across a DBus round-trip blocks
-	// chanListener, preventing the reply from arriving — hard deadlock.
+	// Snapshot ifaceIndexes before the DBus phase. DBus calls must not
+	// execute while holding a.mux: chanListener (the goroutine that
+	// consumes the DBus signal stream delivering replies to these calls)
+	// needs a.mux via processService → getIfaceIndexes. Holding a.mux
+	// across a DBus round-trip blocks chanListener, preventing the reply
+	// from arriving — hard deadlock.
 	//
 	// If UpdateInterfaces mutates a.ifaceIndexes during the DBus phase
 	// below, we commit with the stale snapshot. That's acceptable: the
@@ -242,14 +242,7 @@ func (a *AvahiProvider) Announce(serviceName string, port int, txt []string) err
 	// which pairs every UpdateInterfaces with a follow-up Announce.
 	// That follow-up is serialized behind announceMux and will overwrite
 	// this commit with fresh data before any peer can observe the gap.
-	a.mux.Lock()
-	if a.manualShutdown {
-		a.mux.Unlock()
-		return fmt.Errorf("mdns: avahi provider is shut down")
-	}
-	ifaceIndexes := make([]int32, len(a.ifaceIndexes))
-	copy(ifaceIndexes, a.ifaceIndexes)
-	a.mux.Unlock()
+	ifaceIndexes := a.getIfaceIndexes()
 
 	// All DBus calls happen without holding a.mux.
 	newEntryGroup, err := a.avServer.EntryGroupNew()

--- a/mdns/avahi.go
+++ b/mdns/avahi.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"slices"
 	"sync"
 	"time"
 
@@ -230,99 +229,86 @@ func (a *AvahiProvider) Announce(serviceName string, port int, txt []string) err
 		btxt = append(btxt, []byte(t))
 	}
 
-	// Compare-and-retry loop: snapshot ifaceIndexes, perform DBus calls
-	// without holding a.mux (to avoid deadlock with chanListener), then
-	// verify the snapshot is still current. If interfaces changed during
-	// the DBus phase, discard the work and retry once with fresh data.
-	// The announceMux guarantees no external Announce can interleave, so
-	// a single retry suffices — further changes are left to the existing
-	// reannounceWithNewInterfaces mechanism.
-	for attempt := 0; ; attempt++ {
-		// Snapshot ifaceIndexes under the lock, then release immediately.
-		// DBus calls must not execute while holding a.mux: chanListener
-		// (the goroutine that consumes the DBus signal stream delivering
-		// replies to these calls) needs a.mux via processService →
-		// getIfaceIndexes. Holding a.mux across a DBus round-trip blocks
-		// chanListener, preventing the reply from arriving — hard deadlock.
-		a.mux.Lock()
-		if a.manualShutdown {
-			a.mux.Unlock()
-			return fmt.Errorf("mdns: avahi provider is shut down")
-		}
-		ifaceIndexes := make([]int32, len(a.ifaceIndexes))
-		copy(ifaceIndexes, a.ifaceIndexes)
+	// Snapshot ifaceIndexes under the lock, then release immediately.
+	// DBus calls must not execute while holding a.mux: chanListener
+	// (the goroutine that consumes the DBus signal stream delivering
+	// replies to these calls) needs a.mux via processService →
+	// getIfaceIndexes. Holding a.mux across a DBus round-trip blocks
+	// chanListener, preventing the reply from arriving — hard deadlock.
+	//
+	// If UpdateInterfaces mutates a.ifaceIndexes during the DBus phase
+	// below, we commit with the stale snapshot. That's acceptable: the
+	// only caller of UpdateInterfaces is reannounceWithNewInterfaces,
+	// which pairs every UpdateInterfaces with a follow-up Announce.
+	// That follow-up is serialized behind announceMux and will overwrite
+	// this commit with fresh data before any peer can observe the gap.
+	a.mux.Lock()
+	if a.manualShutdown {
 		a.mux.Unlock()
-
-		// All DBus calls happen without holding a.mux.
-		newEntryGroup, err := a.avServer.EntryGroupNew()
-		if err != nil {
-			return err
-		}
-
-		for _, iface := range ifaceIndexes {
-			// conversion is safe, as port values are always positive
-			err = newEntryGroup.AddService(iface, avahi.ProtoUnspec, 0, serviceName, shipZeroConfServiceType, shipZeroConfDomain, "", uint16(port), btxt) // #nosec G115
-			if err != nil {
-				a.avServer.EntryGroupFree(newEntryGroup)
-				return err
-			}
-		}
-
-		err = newEntryGroup.Commit()
-		if err != nil {
-			a.avServer.EntryGroupFree(newEntryGroup)
-			return err
-		}
-
-		// Re-acquire the lock to update struct state only.
-		// Only store the data for reconnection after a successful commit,
-		// so avahiCallback never re-announces with parameters that were
-		// never successfully committed.
-		a.mux.Lock()
-
-		// Shutdown may have set manualShutdown while we were performing
-		// DBus calls without holding a.mux. Shutdown is blocked on
-		// announceMux so the server is still alive, but storing a new
-		// entry group is pointless — Shutdown's unannounce will free it
-		// immediately. Short-circuit here to avoid the unnecessary state
-		// mutation.
-		if a.manualShutdown {
-			a.mux.Unlock()
-			a.avServer.EntryGroupFree(newEntryGroup)
-			return fmt.Errorf("mdns: avahi provider is shut down")
-		}
-
-		// Only retry once to avoid infinite loops under interface churn.
-		// On the second attempt we proceed regardless — the MdnsManager's
-		// reannounceWithNewInterfaces cycle will reconcile any further drift.
-		if attempt < 1 && !slices.Equal(ifaceIndexes, a.ifaceIndexes) {
-			// Interfaces changed during DBus calls; discard and retry once
-			// with fresh data.
-			a.mux.Unlock()
-			a.avServer.EntryGroupFree(newEntryGroup)
-			continue
-		}
-
-		a.mdnsServiceData = &mdnsServiceData{
-			Name: serviceName,
-			Port: port,
-			Txt:  txt,
-		}
-
-		// Free the old entry group AFTER the new one is committed.
-		// This avoids a window where the service is completely unannounced,
-		// which would cause remote devices to think we left the network.
-		oldEntryGroup := a.avEntryGroup
-		a.avEntryGroup = newEntryGroup
-
-		a.mux.Unlock()
-
-		if oldEntryGroup != nil {
-			a.avServer.EntryGroupFree(oldEntryGroup)
-		}
-
-		return nil
+		return fmt.Errorf("mdns: avahi provider is shut down")
 	}
+	ifaceIndexes := make([]int32, len(a.ifaceIndexes))
+	copy(ifaceIndexes, a.ifaceIndexes)
+	a.mux.Unlock()
+
+	// All DBus calls happen without holding a.mux.
+	newEntryGroup, err := a.avServer.EntryGroupNew()
+	if err != nil {
+		return err
+	}
+
+	for _, iface := range ifaceIndexes {
+		// conversion is safe, as port values are always positive
+		err = newEntryGroup.AddService(iface, avahi.ProtoUnspec, 0, serviceName, shipZeroConfServiceType, shipZeroConfDomain, "", uint16(port), btxt) // #nosec G115
+		if err != nil {
+			a.avServer.EntryGroupFree(newEntryGroup)
+			return err
+		}
+	}
+
+	err = newEntryGroup.Commit()
+	if err != nil {
+		a.avServer.EntryGroupFree(newEntryGroup)
+		return err
+	}
+
+	// Re-acquire the lock to update struct state only.
+	// Only store the data for reconnection after a successful commit,
+	// so avahiCallback never re-announces with parameters that were
+	// never successfully committed.
+	a.mux.Lock()
+
+	// Shutdown may have set manualShutdown while we were performing
+	// DBus calls without holding a.mux. Shutdown is blocked on
+	// announceMux so the server is still alive, but storing a new
+	// entry group is pointless — Shutdown's unannounce will free it
+	// immediately. Short-circuit here to avoid the unnecessary state
+	// mutation.
+	if a.manualShutdown {
+		a.mux.Unlock()
+		a.avServer.EntryGroupFree(newEntryGroup)
+		return fmt.Errorf("mdns: avahi provider is shut down")
+	}
+
+	a.mdnsServiceData = &mdnsServiceData{
+		Name: serviceName,
+		Port: port,
+		Txt:  txt,
+	}
+
+	// Free the old entry group AFTER the new one is committed.
+	// This avoids a window where the service is completely unannounced,
+	// which would cause remote devices to think we left the network.
+	oldEntryGroup := a.avEntryGroup
+	a.avEntryGroup = newEntryGroup
+
+	a.mux.Unlock()
+
+	if oldEntryGroup != nil {
+		a.avServer.EntryGroupFree(oldEntryGroup)
+	}
+
+	return nil
 }
 
 func (a *AvahiProvider) Unannounce() {

--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/enbility/go-avahi"
@@ -77,8 +78,8 @@ type MdnsManager struct {
 	// The port address of the websocket server
 	port int
 
-	// Wether remote devices should be automatically accepted
-	autoaccept bool
+	// Whether remote devices should be automatically accepted
+	autoaccept atomic.Bool
 
 	isAnnounced bool
 
@@ -570,7 +571,7 @@ func (m *MdnsManager) AnnounceMdnsEntry() error {
 		"brand=" + m.deviceBrand,
 		"model=" + m.deviceModel,
 		"type=" + m.deviceType,
-		"register=" + fmt.Sprintf("%v", m.autoaccept),
+		"register=" + fmt.Sprintf("%v", m.autoaccept.Load()),
 	}
 
 	// SHIP Requirements for Installation Process V1.0.0
@@ -628,29 +629,16 @@ func (m *MdnsManager) setIsServiceAnnounce(value bool) {
 }
 
 func (m *MdnsManager) SetAutoAccept(accept bool) {
-	m.autoaccept = accept
+	m.autoaccept.Store(accept)
 
-	// if announcement is off, don't enforce a new announcement
-	if !m.isServiceAnnounced() {
+	if !m.isServiceAnnounced() || m.mdnsProvider == nil {
 		return
 	}
 
-	if m.mdnsProvider == nil {
-		return
+	if err := m.AnnounceMdnsEntry(); err != nil {
+		logging.Log().Debug("mdns: changing mdns entry failed", err)
+		m.setIsServiceAnnounce(false)
 	}
-
-	m.mdnsProvider.Unannounce()
-
-	// Update the announcement as autoaccept changed
-	err := m.AnnounceMdnsEntry()
-
-	if err == nil {
-		return
-	}
-
-	logging.Log().Debug("mdns: changing mdns entry failed", err)
-
-	m.setIsServiceAnnounce(false)
 }
 
 // SetTestProvider injects a mock provider for testing purposes

--- a/mdns/mdns_issues_test.go
+++ b/mdns/mdns_issues_test.go
@@ -539,6 +539,53 @@ func (s *IssuesSuite) Test_AvahiShutdownDoesNotDeadlockOnBusyChanListener() {
 	}
 }
 
+// ---------------------------------------------------------------------
+// MdnsManager.SetAutoAccept() calls Unannounce() before re-announcing,
+// unlike reannounceWithNewInterfaces() which uses create-then-swap.
+// The explicit Unannounce sends mDNS goodbye packets, causing remote
+// devices to think the service left the network. It also performs
+// blocking I/O (DBus / zeroconf Shutdown) that compounds with the
+// muxReg lock-hold issue in Hub.SetAutoAccept.
+//
+// Reproducer: Set up an announced MdnsManager, call SetAutoAccept,
+// and verify that the provider's Unannounce() is NOT called — only
+// Announce() should be called (create-then-swap pattern).
+//
+// EXPECTED (current code): FAIL — Unannounce is called.
+// EXPECTED (after fix):    PASS — only Announce is called.
+// ---------------------------------------------------------------------
+
+func (s *IssuesSuite) Test_SetAutoAcceptDoesNotCallUnannounce() {
+	var unannounced atomic.Bool
+
+	provider := mocks.NewMdnsProviderInterface(s.T())
+	provider.On("Announce", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(nil)
+	provider.On("Unannounce").Maybe().Run(func(_ mock.Arguments) {
+		unannounced.Store(true)
+	}).Return()
+
+	mgr := NewMDNS("test", "brand", "model", "EnergyManagementSystem",
+		"12345",
+		[]api.DeviceCategoryType{api.DeviceCategoryTypeEnergyManagementSystem},
+		"shipid", "serviceName",
+		4729, nil, MdnsProviderSelectionAll)
+	mgr.SetTestProvider(provider)
+	mgr.mdnsProvider = provider
+	mgr.setIsServiceAnnounce(true)
+
+	mgr.SetAutoAccept(true)
+
+	// The provider's Announce should have been called (to re-announce
+	// with the updated autoaccept TXT record).
+	provider.AssertCalled(s.T(), "Announce", mock.Anything, mock.Anything, mock.Anything)
+
+	// Unannounce should NOT have been called. The create-then-swap
+	// pattern used by reannounceWithNewInterfaces avoids goodbye
+	// packets that disrupt remote devices.
+	assert.False(s.T(), unannounced.Load(),
+		"SetAutoAccept must not call Unannounce — use create-then-swap like reannounceWithNewInterfaces")
+}
+
 // Helper: verify avahi.InterfaceUnspec is what we expect
 func init() {
 	_ = avahi.InterfaceUnspec // ensure import is used

--- a/mdns/mdns_issues_test.go
+++ b/mdns/mdns_issues_test.go
@@ -621,7 +621,8 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringEntryGroupNe
 		"", mock.Anything, mock.Anything).Return(nil).Once()
 	entryGroupMock.On("Commit").Return(nil).Once()
 
-	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+	announceDone := make(chan error, 1)
+	go func() { announceDone <- sut.Announce("test", 4729, []string{"txt=1"}) }()
 
 	select {
 	case <-entryGroupNewEntered:
@@ -651,8 +652,12 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringEntryGroupNe
 	}
 
 	close(releaseEntryGroupNew)
-	// Let Announce finish cleanly.
-	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-announceDone:
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Announce did not complete")
+	}
 }
 
 // Test 2: a.mux held across AddService blocks getIfaceIndexes.
@@ -676,7 +681,8 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringAddService()
 		}).Return(nil).Once()
 	entryGroupMock.On("Commit").Return(nil).Once()
 
-	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+	announceDone := make(chan error, 1)
+	go func() { announceDone <- sut.Announce("test", 4729, []string{"txt=1"}) }()
 
 	select {
 	case <-addServiceEntered:
@@ -700,7 +706,12 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringAddService()
 	}
 
 	close(releaseAddService)
-	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-announceDone:
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Announce did not complete")
+	}
 }
 
 // Test 3: a.mux held across Commit blocks getIfaceIndexes.
@@ -724,7 +735,8 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringCommit() {
 			<-releaseCommit
 		}).Return(nil).Once()
 
-	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+	announceDone := make(chan error, 1)
+	go func() { announceDone <- sut.Announce("test", 4729, []string{"txt=1"}) }()
 
 	select {
 	case <-commitEntered:
@@ -748,7 +760,12 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringCommit() {
 	}
 
 	close(releaseCommit)
-	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-announceDone:
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Announce did not complete")
+	}
 }
 
 // Test 4 (crown jewel): Full chanListener deadlock simulation.
@@ -868,6 +885,8 @@ func (s *IssuesSuite) Test_AnnounceDuringActiveServiceDiscoveryDoesNotDeadlock()
 	}
 
 	// Clean shutdown.
+	// Shutdown → Unannounce frees the entry group that Announce stored.
+	avahiMock.EXPECT().EntryGroupFree(entryGroupMock).Return().Once()
 	avahiMock.EXPECT().ServiceBrowserFree(serviceBrowserMock).Return().Once()
 	avahiMock.EXPECT().Shutdown().Return().Once()
 	sut.Shutdown()
@@ -878,7 +897,8 @@ func (s *IssuesSuite) Test_AnnounceDuringActiveServiceDiscoveryDoesNotDeadlock()
 // interfaces while Announce is mid-DBus would stall.
 func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
 	avahiMock := avahiMocks.NewServerInterface(s.T())
-	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+	firstEntryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+	secondEntryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
 
 	sut := NewAvahiProvider([]int32{1})
 	sut.avServer = avahiMock
@@ -886,16 +906,29 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
 	entryGroupNewEntered := make(chan struct{})
 	releaseEntryGroupNew := make(chan struct{})
 
+	// First attempt: blocks in EntryGroupNew while UpdateInterfaces changes ifaceIndexes.
+	// After the DBus phase completes, the compare-and-retry logic detects the
+	// stale snapshot and discards this entry group.
 	avahiMock.On("EntryGroupNew").Run(func(_ mock.Arguments) {
 		close(entryGroupNewEntered)
 		<-releaseEntryGroupNew
-	}).Return(entryGroupMock, nil).Once()
-	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+	}).Return(firstEntryGroupMock, nil).Once()
+	firstEntryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
 		"test", shipZeroConfServiceType, shipZeroConfDomain,
 		"", mock.Anything, mock.Anything).Return(nil).Once()
-	entryGroupMock.On("Commit").Return(nil).Once()
+	firstEntryGroupMock.On("Commit").Return(nil).Once()
+	// First entry group is freed when the stale snapshot is detected
+	avahiMock.On("EntryGroupFree", firstEntryGroupMock).Return()
 
-	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+	// Second attempt: uses fresh ifaceIndexes {1, 2} — two AddService calls.
+	avahiMock.On("EntryGroupNew").Return(secondEntryGroupMock, nil).Once()
+	secondEntryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).Return(nil).Twice()
+	secondEntryGroupMock.On("Commit").Return(nil).Once()
+
+	announceDone := make(chan error, 1)
+	go func() { announceDone <- sut.Announce("test", 4729, []string{"txt=1"}) }()
 
 	select {
 	case <-entryGroupNewEntered:
@@ -920,14 +953,24 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
 	}
 
 	close(releaseEntryGroupNew)
-	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case err := <-announceDone:
+		s.Require().NoError(err)
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Announce did not complete")
+	}
+
+	// Verify the provider ended up with the fresh interfaces
+	s.Equal([]int32{1, 2}, sut.getIfaceIndexes())
 }
 
-// Test 6: Announce must not block Shutdown.
-// Shutdown (line 151) acquires a.mux. If called while Announce is
-// mid-DBus, the entire provider is wedged — can't shut down, can't
-// discover, can't announce.
-func (s *IssuesSuite) Test_AnnounceDoesNotBlockShutdown() {
+// Test 6: Shutdown waits for in-flight Announce via announceMux, then
+// proceeds with orderly teardown. Shutdown must not deadlock on a.mux
+// (the original bug), but it SHOULD wait for the in-flight Announce to
+// finish so that no zombie entry group is left referencing a shut-down
+// server.
+func (s *IssuesSuite) Test_ShutdownWaitsForInflightAnnounce() {
 	avahiMock := avahiMocks.NewServerInterface(s.T())
 	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
 
@@ -947,8 +990,12 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockShutdown() {
 			close(commitEntered)
 			<-releaseCommit
 		}).Return(nil).Once()
+	// Shutdown's Unannounce frees the entry group that Announce stored.
+	avahiMock.On("EntryGroupFree", entryGroupMock).Return().Once()
+	avahiMock.On("Shutdown").Return().Once()
 
-	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+	announceDone := make(chan error, 1)
+	go func() { announceDone <- sut.Announce("test", 4729, []string{"txt=1"}) }()
 
 	select {
 	case <-commitEntered:
@@ -957,27 +1004,40 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockShutdown() {
 		s.T().Fatal("Commit was never entered")
 	}
 
-	avahiMock.EXPECT().Shutdown().Return().Maybe()
-
 	shutdownDone := make(chan struct{})
 	go func() {
 		sut.Shutdown()
 		close(shutdownDone)
 	}()
 
+	// Shutdown should NOT complete while Announce is still blocked in
+	// Commit, because Shutdown acquires announceMux to wait for it.
 	select {
 	case <-shutdownDone:
-		// PASS: Shutdown is not blocked by Announce's lock.
-	case <-time.After(500 * time.Millisecond):
+		close(releaseCommit)
 		s.T().Fatal(
-			"CONTENTION: Shutdown blocked for >500ms while Announce held " +
-				"a.mux inside Commit. If the system decides to shut down " +
-				"during announcement (e.g. user-initiated or avahi disconnect), " +
-				"it must not wait for a DBus round-trip to complete.")
+			"Shutdown completed while Announce was still in-flight. " +
+				"announceMux should make Shutdown wait for the in-flight " +
+				"Announce to finish before tearing down the server.")
+	case <-time.After(200 * time.Millisecond):
+		// PASS: Shutdown is correctly waiting for Announce.
 	}
 
+	// Release Announce — both should now complete.
 	close(releaseCommit)
-	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-announceDone:
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Announce did not complete after Commit was released")
+	}
+
+	select {
+	case <-shutdownDone:
+		// PASS: Shutdown completed after Announce finished.
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Shutdown did not complete after Announce finished")
+	}
 }
 
 // Helper: verify avahi.InterfaceUnspec is what we expect

--- a/mdns/mdns_issues_test.go
+++ b/mdns/mdns_issues_test.go
@@ -586,6 +586,400 @@ func (s *IssuesSuite) Test_SetAutoAcceptDoesNotCallUnannounce() {
 		"SetAutoAccept must not call Unannounce — use create-then-swap like reannounceWithNewInterfaces")
 }
 
+// ---------------------------------------------------------------------
+// Issue #2: AvahiProvider.Announce() holds a.mux across DBus calls
+// (EntryGroupNew, AddService, Commit). chanListener — the goroutine
+// that consumes the DBus signal stream delivering replies to those
+// calls — needs a.mux via processService → getIfaceIndexes. Blocking
+// chanListener prevents DBus reply delivery: hard deadlock.
+//
+// Tests 1-3 isolate the contention to each individual DBus call.
+// Test 4 reproduces the full deadlock chain with a live chanListener.
+// Tests 5-6 show collateral damage to other a.mux callers.
+//
+// All tests assert CORRECT (fixed) behavior: they FAIL against the
+// current code and PASS once the fix is applied.
+// ---------------------------------------------------------------------
+
+// Test 1: a.mux held across EntryGroupNew blocks getIfaceIndexes.
+func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringEntryGroupNew() {
+	avahiMock := avahiMocks.NewServerInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+
+	sut := NewAvahiProvider([]int32{1})
+	sut.avServer = avahiMock
+
+	entryGroupNewEntered := make(chan struct{})
+	releaseEntryGroupNew := make(chan struct{})
+
+	avahiMock.On("EntryGroupNew").Run(func(_ mock.Arguments) {
+		close(entryGroupNewEntered)
+		<-releaseEntryGroupNew
+	}).Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).Return(nil).Once()
+	entryGroupMock.On("Commit").Return(nil).Once()
+
+	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+
+	select {
+	case <-entryGroupNewEntered:
+	case <-time.After(2 * time.Second):
+		close(releaseEntryGroupNew)
+		s.T().Fatal("EntryGroupNew was never entered")
+	}
+
+	// a.mux is now held by Announce, inside EntryGroupNew.
+	// getIfaceIndexes must complete promptly — it must not contend on a.mux.
+	ifacesDone := make(chan struct{})
+	go func() {
+		_ = sut.getIfaceIndexes()
+		close(ifacesDone)
+	}()
+
+	select {
+	case <-ifacesDone:
+		// PASS: a.mux is not held across the DBus call.
+	case <-time.After(500 * time.Millisecond):
+		s.T().Fatal(
+			"CONTENTION: getIfaceIndexes blocked for >500ms while Announce " +
+				"held a.mux inside EntryGroupNew. In production, chanListener " +
+				"calls getIfaceIndexes — blocking it prevents DBus reply " +
+				"delivery, causing a hard deadlock. Fix: release a.mux before " +
+				"DBus calls (EntryGroupNew, AddService, Commit).")
+	}
+
+	close(releaseEntryGroupNew)
+	// Let Announce finish cleanly.
+	time.Sleep(100 * time.Millisecond)
+}
+
+// Test 2: a.mux held across AddService blocks getIfaceIndexes.
+func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringAddService() {
+	avahiMock := avahiMocks.NewServerInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+
+	sut := NewAvahiProvider([]int32{1})
+	sut.avServer = avahiMock
+
+	addServiceEntered := make(chan struct{})
+	releaseAddService := make(chan struct{})
+
+	avahiMock.On("EntryGroupNew").Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) {
+			close(addServiceEntered)
+			<-releaseAddService
+		}).Return(nil).Once()
+	entryGroupMock.On("Commit").Return(nil).Once()
+
+	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+
+	select {
+	case <-addServiceEntered:
+	case <-time.After(2 * time.Second):
+		close(releaseAddService)
+		s.T().Fatal("AddService was never entered")
+	}
+
+	ifacesDone := make(chan struct{})
+	go func() {
+		_ = sut.getIfaceIndexes()
+		close(ifacesDone)
+	}()
+
+	select {
+	case <-ifacesDone:
+	case <-time.After(500 * time.Millisecond):
+		s.T().Fatal(
+			"CONTENTION: getIfaceIndexes blocked while Announce held a.mux " +
+				"inside AddService. Same deadlock vector as EntryGroupNew.")
+	}
+
+	close(releaseAddService)
+	time.Sleep(100 * time.Millisecond)
+}
+
+// Test 3: a.mux held across Commit blocks getIfaceIndexes.
+func (s *IssuesSuite) Test_AnnounceDoesNotBlockGetIfaceIndexesDuringCommit() {
+	avahiMock := avahiMocks.NewServerInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+
+	sut := NewAvahiProvider([]int32{1})
+	sut.avServer = avahiMock
+
+	commitEntered := make(chan struct{})
+	releaseCommit := make(chan struct{})
+
+	avahiMock.On("EntryGroupNew").Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).Return(nil).Once()
+	entryGroupMock.On("Commit").
+		Run(func(_ mock.Arguments) {
+			close(commitEntered)
+			<-releaseCommit
+		}).Return(nil).Once()
+
+	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+
+	select {
+	case <-commitEntered:
+	case <-time.After(2 * time.Second):
+		close(releaseCommit)
+		s.T().Fatal("Commit was never entered")
+	}
+
+	ifacesDone := make(chan struct{})
+	go func() {
+		_ = sut.getIfaceIndexes()
+		close(ifacesDone)
+	}()
+
+	select {
+	case <-ifacesDone:
+	case <-time.After(500 * time.Millisecond):
+		s.T().Fatal(
+			"CONTENTION: getIfaceIndexes blocked while Announce held a.mux " +
+				"inside Commit.")
+	}
+
+	close(releaseCommit)
+	time.Sleep(100 * time.Millisecond)
+}
+
+// Test 4 (crown jewel): Full chanListener deadlock simulation.
+//
+// Start the provider so chanListener is running. Block EntryGroupNew
+// (simulating a DBus round-trip) while Announce holds a.mux. Inject a
+// service event on addServiceChan. chanListener picks it up but blocks
+// in getIfaceIndexes on a.mux. In production the DBus reply to
+// EntryGroupNew is delivered through chanListener — with it blocked,
+// the reply never arrives. Neither goroutine can proceed: hard deadlock.
+func (s *IssuesSuite) Test_AnnounceDuringActiveServiceDiscoveryDoesNotDeadlock() {
+	avahiMock := avahiMocks.NewServerInterface(s.T())
+	serviceBrowserMock := avahiMocks.NewServiceBrowserInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+
+	sut := NewAvahiProvider([]int32{1})
+	sut.avServer = avahiMock
+
+	// Start the provider — spawns chanListener goroutine.
+	avahiMock.EXPECT().Setup(mock.Anything).Return(nil).Once()
+	avahiMock.EXPECT().Start().Return().Once()
+	avahiMock.EXPECT().GetAPIVersion().Return(int32(0), nil).Once()
+	avahiMock.EXPECT().ServiceBrowserNew(
+		mock.AnythingOfType("chan avahi.Service"),
+		mock.AnythingOfType("chan avahi.Service"),
+		int32(-1), int32(-1),
+		shipZeroConfServiceType, shipZeroConfDomain,
+		uint32(0)).Return(serviceBrowserMock, nil).Once()
+
+	noopCB := func(map[string]string, string, string, []net.IP, int, bool) {}
+	assert.True(s.T(), sut.Start(true, noopCB))
+
+	// Give chanListener time to enter its select loop.
+	time.Sleep(50 * time.Millisecond)
+
+	// Mock EntryGroupNew to block, simulating a DBus round-trip.
+	entryGroupNewEntered := make(chan struct{})
+	releaseEntryGroupNew := make(chan struct{})
+	avahiMock.On("EntryGroupNew").
+		Run(func(_ mock.Arguments) {
+			close(entryGroupNewEntered)
+			<-releaseEntryGroupNew
+		}).Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).Return(nil).Once()
+	entryGroupMock.On("Commit").Return(nil).Once()
+
+	// Start Announce — acquires a.mux and enters the blocked EntryGroupNew.
+	announceDone := make(chan error, 1)
+	go func() {
+		announceDone <- sut.Announce("test", 4729, []string{"txt=1"})
+	}()
+
+	select {
+	case <-entryGroupNewEntered:
+	case <-time.After(2 * time.Second):
+		close(releaseEntryGroupNew)
+		s.T().Fatal("EntryGroupNew was never entered")
+	}
+
+	// Announce now holds a.mux inside EntryGroupNew.
+	// Inject a service event — chanListener will pick it up and enter
+	// processService → getIfaceIndexes → a.mux.Lock() → BLOCKED.
+	//
+	// In production this creates a hard deadlock: chanListener is the
+	// DBus signal consumer, and with it blocked, the reply to
+	// EntryGroupNew can never be delivered.
+	testService := avahi.Service{
+		Interface: 1,
+		Name:      "DiscoveredDuringAnnounce",
+		Type:      "_ship._tcp",
+		Domain:    "local",
+		Aprotocol: -1,
+	}
+
+	// ResolveService mock — chanListener calls this if it gets past
+	// getIfaceIndexes. With the bug, it never reaches this point.
+	resolveReached := make(chan struct{}, 1)
+	avahiMock.On("ResolveService",
+		mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(_ mock.Arguments) {
+		select {
+		case resolveReached <- struct{}{}:
+		default:
+		}
+	}).Return(avahi.Service{Address: "127.0.0.1"}, nil).Maybe()
+
+	// Send the service. chanListener reads it from addServiceChan,
+	// enters processService, and (with the bug) blocks on getIfaceIndexes.
+	sut.addServiceChan <- testService
+
+	// EXPECTED (correct behavior): chanListener should fully process the
+	// service because a.mux is NOT held during EntryGroupNew.
+	select {
+	case <-resolveReached:
+		// PASS: chanListener was not blocked by Announce's lock.
+	case <-time.After(500 * time.Millisecond):
+		s.T().Fatal(
+			"DEADLOCK: chanListener is blocked in getIfaceIndexes on a.mux " +
+				"while Announce holds a.mux inside EntryGroupNew. In production " +
+				"chanListener is the DBus signal consumer — blocking it prevents " +
+				"the EntryGroupNew reply from being delivered. Neither goroutine " +
+				"can make progress. This is the exact deadlock described in the " +
+				"goroutine dump. Fix: release a.mux before calling EntryGroupNew, " +
+				"AddService, and Commit — the mutex should protect struct-state " +
+				"updates only, not span DBus round-trips.")
+	}
+
+	close(releaseEntryGroupNew)
+
+	select {
+	case <-announceDone:
+	case <-time.After(2 * time.Second):
+		s.T().Fatal("Announce did not complete")
+	}
+
+	// Clean shutdown.
+	avahiMock.EXPECT().ServiceBrowserFree(serviceBrowserMock).Return().Once()
+	avahiMock.EXPECT().Shutdown().Return().Once()
+	sut.Shutdown()
+}
+
+// Test 5: Announce must not block UpdateInterfaces.
+// UpdateInterfaces (line 66) acquires a.mux. A caller updating network
+// interfaces while Announce is mid-DBus would stall.
+func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
+	avahiMock := avahiMocks.NewServerInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+
+	sut := NewAvahiProvider([]int32{1})
+	sut.avServer = avahiMock
+
+	entryGroupNewEntered := make(chan struct{})
+	releaseEntryGroupNew := make(chan struct{})
+
+	avahiMock.On("EntryGroupNew").Run(func(_ mock.Arguments) {
+		close(entryGroupNewEntered)
+		<-releaseEntryGroupNew
+	}).Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).Return(nil).Once()
+	entryGroupMock.On("Commit").Return(nil).Once()
+
+	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+
+	select {
+	case <-entryGroupNewEntered:
+	case <-time.After(2 * time.Second):
+		close(releaseEntryGroupNew)
+		s.T().Fatal("EntryGroupNew was never entered")
+	}
+
+	updateDone := make(chan struct{})
+	go func() {
+		sut.UpdateInterfaces(nil, []int32{1, 2})
+		close(updateDone)
+	}()
+
+	select {
+	case <-updateDone:
+	case <-time.After(500 * time.Millisecond):
+		s.T().Fatal(
+			"CONTENTION: UpdateInterfaces blocked for >500ms while Announce " +
+				"held a.mux inside EntryGroupNew. Interface updates (e.g. from " +
+				"the refresh goroutine) must not stall on DBus round-trip latency.")
+	}
+
+	close(releaseEntryGroupNew)
+	time.Sleep(100 * time.Millisecond)
+}
+
+// Test 6: Announce must not block Shutdown.
+// Shutdown (line 151) acquires a.mux. If called while Announce is
+// mid-DBus, the entire provider is wedged — can't shut down, can't
+// discover, can't announce.
+func (s *IssuesSuite) Test_AnnounceDoesNotBlockShutdown() {
+	avahiMock := avahiMocks.NewServerInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+
+	sut := NewAvahiProvider([]int32{1})
+	sut.avServer = avahiMock
+	sut.setupSuccessful = true
+
+	commitEntered := make(chan struct{})
+	releaseCommit := make(chan struct{})
+
+	avahiMock.On("EntryGroupNew").Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+		"test", shipZeroConfServiceType, shipZeroConfDomain,
+		"", mock.Anything, mock.Anything).Return(nil).Once()
+	entryGroupMock.On("Commit").
+		Run(func(_ mock.Arguments) {
+			close(commitEntered)
+			<-releaseCommit
+		}).Return(nil).Once()
+
+	go func() { _ = sut.Announce("test", 4729, []string{"txt=1"}) }()
+
+	select {
+	case <-commitEntered:
+	case <-time.After(2 * time.Second):
+		close(releaseCommit)
+		s.T().Fatal("Commit was never entered")
+	}
+
+	avahiMock.EXPECT().Shutdown().Return().Maybe()
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		sut.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+		// PASS: Shutdown is not blocked by Announce's lock.
+	case <-time.After(500 * time.Millisecond):
+		s.T().Fatal(
+			"CONTENTION: Shutdown blocked for >500ms while Announce held " +
+				"a.mux inside Commit. If the system decides to shut down " +
+				"during announcement (e.g. user-initiated or avahi disconnect), " +
+				"it must not wait for a DBus round-trip to complete.")
+	}
+
+	close(releaseCommit)
+	time.Sleep(100 * time.Millisecond)
+}
+
 // Helper: verify avahi.InterfaceUnspec is what we expect
 func init() {
 	_ = avahi.InterfaceUnspec // ensure import is used

--- a/mdns/mdns_issues_test.go
+++ b/mdns/mdns_issues_test.go
@@ -894,11 +894,19 @@ func (s *IssuesSuite) Test_AnnounceDuringActiveServiceDiscoveryDoesNotDeadlock()
 
 // Test 5: Announce must not block UpdateInterfaces.
 // UpdateInterfaces (line 66) acquires a.mux. A caller updating network
-// interfaces while Announce is mid-DBus would stall.
+// interfaces while Announce is mid-DBus would stall. Announce releases
+// a.mux across its DBus phase precisely so that UpdateInterfaces (and
+// chanListener) can proceed in parallel.
+//
+// If UpdateInterfaces mutates a.ifaceIndexes during the DBus phase, the
+// in-flight Announce commits with the stale snapshot. That is acceptable
+// because the only production caller of UpdateInterfaces is
+// reannounceWithNewInterfaces, which pairs every UpdateInterfaces with a
+// follow-up Announce (serialized behind announceMux) that overwrites the
+// stale commit with fresh data.
 func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
 	avahiMock := avahiMocks.NewServerInterface(s.T())
-	firstEntryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
-	secondEntryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
+	entryGroupMock := avahiMocks.NewEntryGroupInterface(s.T())
 
 	sut := NewAvahiProvider([]int32{1})
 	sut.avServer = avahiMock
@@ -906,26 +914,17 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
 	entryGroupNewEntered := make(chan struct{})
 	releaseEntryGroupNew := make(chan struct{})
 
-	// First attempt: blocks in EntryGroupNew while UpdateInterfaces changes ifaceIndexes.
-	// After the DBus phase completes, the compare-and-retry logic detects the
-	// stale snapshot and discards this entry group.
+	// Announce snapshots ifaceIndexes=[1], releases a.mux, then blocks in
+	// EntryGroupNew (simulating a DBus round-trip). UpdateInterfaces must
+	// not stall while Announce is parked here.
 	avahiMock.On("EntryGroupNew").Run(func(_ mock.Arguments) {
 		close(entryGroupNewEntered)
 		<-releaseEntryGroupNew
-	}).Return(firstEntryGroupMock, nil).Once()
-	firstEntryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
+	}).Return(entryGroupMock, nil).Once()
+	entryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
 		"test", shipZeroConfServiceType, shipZeroConfDomain,
 		"", mock.Anything, mock.Anything).Return(nil).Once()
-	firstEntryGroupMock.On("Commit").Return(nil).Once()
-	// First entry group is freed when the stale snapshot is detected
-	avahiMock.On("EntryGroupFree", firstEntryGroupMock).Return()
-
-	// Second attempt: uses fresh ifaceIndexes {1, 2} — two AddService calls.
-	avahiMock.On("EntryGroupNew").Return(secondEntryGroupMock, nil).Once()
-	secondEntryGroupMock.On("AddService", mock.Anything, mock.Anything, mock.Anything,
-		"test", shipZeroConfServiceType, shipZeroConfDomain,
-		"", mock.Anything, mock.Anything).Return(nil).Twice()
-	secondEntryGroupMock.On("Commit").Return(nil).Once()
+	entryGroupMock.On("Commit").Return(nil).Once()
 
 	announceDone := make(chan error, 1)
 	go func() { announceDone <- sut.Announce("test", 4729, []string{"txt=1"}) }()
@@ -961,7 +960,8 @@ func (s *IssuesSuite) Test_AnnounceDoesNotBlockUpdateInterfaces() {
 		s.T().Fatal("Announce did not complete")
 	}
 
-	// Verify the provider ended up with the fresh interfaces
+	// UpdateInterfaces mutated a.ifaceIndexes directly and independently of
+	// Announce's snapshot — confirm the post-state reflects that mutation.
 	s.Equal([]int32{1, 2}, sut.getIfaceIndexes())
 }
 

--- a/mdns/mdns_test.go
+++ b/mdns/mdns_test.go
@@ -155,10 +155,10 @@ func (s *MdnsSuite) Test_GoZeroConfOnly() {
 
 	err := s.sut.Start(s.mdnsSearch)
 	assert.Nil(s.T(), err)
-	assert.False(s.T(), s.sut.autoaccept)
+	assert.False(s.T(), s.sut.autoaccept.Load())
 
 	s.sut.SetAutoAccept(true)
-	assert.True(s.T(), s.sut.autoaccept)
+	assert.True(s.T(), s.sut.autoaccept.Load())
 }
 
 func (s *MdnsSuite) Test_Start() {
@@ -203,7 +203,7 @@ func (s *MdnsSuite) Test_Start_IFaces_Invalid() {
 	assert.False(s.T(), s.sut.isAnnounced)
 
 	s.sut.SetAutoAccept(true)
-	assert.Equal(s.T(), true, s.sut.autoaccept)
+	assert.Equal(s.T(), true, s.sut.autoaccept.Load())
 
 	s.sut.Shutdown()
 }
@@ -1342,10 +1342,10 @@ func (s *MdnsSuite) Test_AutoAcceptServiceUnannouncedYet() {
 	s.sut.isAnnounced = false
 
 	s.sut.SetAutoAccept(true)
-	assert.True(s.T(), s.sut.autoaccept)
+	assert.True(s.T(), s.sut.autoaccept.Load())
 
 	s.sut.SetAutoAccept(false)
-	assert.False(s.T(), s.sut.autoaccept)
+	assert.False(s.T(), s.sut.autoaccept.Load())
 
 	assert.False(s.T(), s.sut.isAnnounced)
 
@@ -1361,10 +1361,10 @@ func (s *MdnsSuite) Test_AutoAcceptMdnsProviderNil() {
 	s.sut.isAnnounced = true
 
 	s.sut.SetAutoAccept(true)
-	assert.True(s.T(), s.sut.autoaccept)
+	assert.True(s.T(), s.sut.autoaccept.Load())
 
 	s.sut.SetAutoAccept(false)
-	assert.False(s.T(), s.sut.autoaccept)
+	assert.False(s.T(), s.sut.autoaccept.Load())
 
 	assert.True(s.T(), s.sut.isAnnounced)
 
@@ -1383,12 +1383,12 @@ func (s *MdnsSuite) Test_AutoAcceptServiceAlreadyAnnounced() {
 	mdnsProvider.EXPECT().Unannounce()
 	mdnsProvider.EXPECT().Announce(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.sut.SetAutoAccept(true)
-	assert.True(s.T(), s.sut.autoaccept)
+	assert.True(s.T(), s.sut.autoaccept.Load())
 
 	mdnsProvider.EXPECT().Unannounce()
 	mdnsProvider.EXPECT().Announce(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.sut.SetAutoAccept(false)
-	assert.False(s.T(), s.sut.autoaccept)
+	assert.False(s.T(), s.sut.autoaccept.Load())
 
 	assert.True(s.T(), s.sut.isAnnounced)
 	mdnsProvider.EXPECT().Shutdown()
@@ -1401,10 +1401,9 @@ func (s *MdnsSuite) Test_AutoAcceptMdnsProviderReannounceFails() {
 	// something has already been announced
 	s.sut.isAnnounced = true
 
-	mdnsProvider.EXPECT().Unannounce()
 	mdnsProvider.EXPECT().Announce(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("myError"))
 	s.sut.SetAutoAccept(true)
-	assert.True(s.T(), s.sut.autoaccept)
+	assert.True(s.T(), s.sut.autoaccept.Load())
 	assert.False(s.T(), s.sut.isAnnounced)
 
 	mdnsProvider.EXPECT().Shutdown()


### PR DESCRIPTION
Hi,

conducting further tests using pull request #76 I discovered a secondary dead-lock within the implementation of Avahi. I analyzed the issue using a dump of eebus-go. Here are my findings and the chain of events:

Goroutine A (the RPC handler calling Announce) is blocked on the go-avahi Server's mutex inside EntryGroupNew, not on its own state. Tracing the other waiters in the log:

Goroutine B (chanListener) is in AvahiProvider.chanListener → processService → getIfaceIndexes, waiting on AvahiProvider.mu. That is the provider's own mutex — and AvahiProvider.Announce (goroutine A) took that mutex on entry (see avahi.go:210) and is still holding it while stuck inside EntryGroupNew.
Goroutine C (DBus signal dispatcher) is in go-avahi.(*ServiceBrowser).DispatchSignal → runtime.chansend, parked trying to hand a DBus signal to the service-browser channel whose reader is goroutine B (chanListener) — which itself is parked on AvahiProvider.mu.
So the chain is:

Goroutine A — RPC handler (Announce)
holds AvahiProvider.mu
holds hub.muxReg
waits go-avahi Server.mu <-- inside EntryGroupNew

Goroutine B — chanListener
waits AvahiProvider.mu <-- held by A

Goroutine C — DBus signal dispatcher
waits send on ServiceBrowser channel <-- reader is B

Goroutines D, E, … — other RPC handlers
wait hub.muxReg <-- held by A

DBus replies to EntryGroupNew are delivered over this same signal plumbing. With the dispatcher (C) parked on a full channel and the consumer (B) parked on AvahiProvider.mu, the reply that would unblock EntryGroupNew can never arrive. That is a hard deadlock, not a slow DBus — it will never recover on its own.

It'd be great if you could have a look and confirm my findings and the corresponding fix. Thank you.

PS: Please note that the proposed fix is based on my other open pull request #76 and should be merged after it.