### PR TITLE
ship: tear down connection on a failed spine data write

### DIFF
--- a/ship/connection_serialization.go
+++ b/ship/connection_serialization.go
@@ -70,6 +70,8 @@ func (c *ShipConnection) sendSpineData(data []byte) error {
 	err = c.dataWriter.WriteMessageToWebsocketConnection(shipMsg)
 	if err != nil {
 		logging.Log().Debug("error sending message: ", err)
+		// tear down so the SKI is freed for reconnect instead of a zombie writer
+		c.CloseConnection(false, 0, "")
 		return err
 	}
 

--- a/ship/connection_serialization.go
+++ b/ship/connection_serialization.go
@@ -67,8 +67,7 @@ func (c *ShipConnection) sendSpineData(data []byte) error {
 	shipMsg := []byte{model.MsgTypeData}
 	shipMsg = append(shipMsg, eebusMsg...)
 
-	err = c.dataWriter.WriteMessageToWebsocketConnection(shipMsg)
-	if err != nil {
+	if err := c.dataWriter.WriteMessageToWebsocketConnection(shipMsg); err != nil {
 		logging.Log().Debug("error sending message: ", err)
 		// tear down so the SKI is freed for reconnect instead of a zombie writer
 		c.CloseConnection(false, 0, "")

--- a/ship/connection_serialization_test.go
+++ b/ship/connection_serialization_test.go
@@ -144,6 +144,8 @@ func (s *ConnectionSerializationSuite) TestSendSpineData_WriteError() {
 	// Mock write error
 	expectedErr := errors.New("write failed")
 	s.wsDataWriter.EXPECT().WriteMessageToWebsocketConnection(mock.Anything).Return(expectedErr).Once()
+	// a failed write must tear down the connection so the SKI is freed for reconnect
+	s.infoProvider.EXPECT().HandleConnectionClosed(s.sut, false).Return().Once()
 
 	err := s.sut.sendSpineData(spineData)
 	assert.Error(s.T(), err)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/31465

Found while chasing an intermittent double-connection related test hang in evcc (evcc-io/evcc#31493) that reproduces on top of #85's dedup fix.

`sendSpineData` only calls `CloseConnection` when `IsDataConnectionClosed()` already reports the connection closed:

```go
if isClosed, err := c.dataWriter.IsDataConnectionClosed(); isClosed {
    c.CloseConnection(false, 0, "")
    return err
}
...
err = c.dataWriter.WriteMessageToWebsocketConnection(shipMsg)
if err != nil {
    logging.Log().Debug("error sending message: ", err)
    return err
}
```

If the actual websocket write fails for any other reason (e.g. the remote already closed the connection before this side's writer noticed), the error is logged and swallowed, but the connection is never torn down. The `ShipConnection` stays registered as the current writer for that SKI, so every subsequent send silently fails forever and the SKI is never freed for a fresh connection attempt.

This surfaced concretely while stress-testing a double-connection race scenario: after one side's connection was implicitly invalidated, the other kept retrying sends against it every couple of seconds indefinitely ("Error sending spine message: connection closed for remote SKI ...", repeating), and no reconnect was ever attempted.

Fix: also call `CloseConnection(false, 0, "")` when the write itself errors, mirroring the existing `IsDataConnectionClosed` branch. Updated `TestSendSpineData_WriteError` to expect the resulting `HandleConnectionClosed` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
