### PR TITLE
hub: keep reconnecting trusted devices that briefly leave mDNS

### DIFF
--- a/hub/hub_mdns.go
+++ b/hub/hub_mdns.go
@@ -134,6 +134,11 @@ func (h *Hub) cleanupRemovedMdnsEntries(currentEntries map[string]*api.MdnsEntry
 	// Check each previous entry to see if it's still present
 	for _, prevEntry := range previousEntries {
 		if !currentSKIs[prevEntry.Ski] {
+			// Keep retrying trusted/paired devices: a transient mDNS drop (e.g.
+			// a remote restart before it re-announces) must not strand reconnects.
+			if h.IsRemoteServiceForSKIPaired(prevEntry.Ski) {
+				continue
+			}
 			// SKI is no longer in mDNS - cancel connection attempts immediately
 			logging.Log().Debugf("hub: cleaning up connection attempts for SKI %s (no longer in mDNS)", prevEntry.Ski)
 			h.cancelConnectionDelayTimer(prevEntry.Ski)

--- a/hub/hub_mdns_test.go
+++ b/hub/hub_mdns_test.go
@@ -531,4 +531,42 @@ func TestReportMdnsEntries_CleanupWithNoPreviousEntries(t *testing.T) {
 	mockHubReader.AssertExpectations(t)
 }
 
+// TestReportMdnsEntries_TrustedServiceSurvivesTransientMdnsDrop: a paired device
+// briefly absent from one mDNS snapshot must keep its pending reconnect.
+func TestReportMdnsEntries_TrustedServiceSurvivesTransientMdnsDrop(t *testing.T) {
+	mockMdns := mocks.NewMdnsInterface(t)
+	mockMdns.EXPECT().RequestMdnsEntries().Maybe()
+	mockMdns.EXPECT().AnnounceMdnsEntry().Return(nil).Maybe()
+
+	hub := newMdnsTestHub(mockMdns)
+
+	mockHubReader := mocks.NewHubReaderInterface(t)
+	mockHubReader.EXPECT().VisibleRemoteMdnsServicesUpdated(mock.AnythingOfType("[]api.RemoteMdnsService")).Maybe()
+	hub.hubReader = mockHubReader
+
+	// A trusted, paired remote we have been asked to (re)connect to.
+	ski := "0123456789abcdef0123456789abcdefffffffff"
+	service, err := api.NewServiceDetails(ski, "", "")
+	assert.NoError(t, err)
+	service.SetTrusted(true)
+	service.ConnectionStateDetail().SetState(api.ConnectionStateQueued)
+	hub.remoteServices = append(hub.remoteServices, service)
+
+	// A reconnect dial has already been scheduled for this SKI.
+	hub.connectionAttemptCounter[ski] = 0
+	hub.connectionDelayTimers[ski] = newConnectionDelayTimer(time.Hour, func() {})
+
+	// The remote was present in the previous mDNS snapshot ...
+	hub.knownMdnsEntries = []*api.MdnsEntry{{Name: "Service 1", Ski: ski, Identifier: "ID1"}}
+
+	// ... but is absent from the next one for a moment.
+	hub.ReportMdnsEntries(map[string]*api.MdnsEntry{}, true)
+
+	// The pending reconnect to the trusted device must survive the transient drop.
+	assert.Contains(t, hub.connectionDelayTimers, ski,
+		"pending reconnect timer for a trusted device must survive a transient mDNS drop")
+	assert.Contains(t, hub.connectionAttemptCounter, ski,
+		"connection attempt counter for a trusted device must survive a transient mDNS drop")
+}
+
 // Create tests the cover ReportMdnsEntries implementation

--- a/hub/hub_mdns_test.go
+++ b/hub/hub_mdns_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/enbility/ship-go/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // newMdnsTestHub builds a Hub with the state ReportMdnsEntries touches.
@@ -547,26 +548,31 @@ func TestReportMdnsEntries_TrustedServiceSurvivesTransientMdnsDrop(t *testing.T)
 	// A trusted, paired remote we have been asked to (re)connect to.
 	ski := "0123456789abcdef0123456789abcdefffffffff"
 	service, err := api.NewServiceDetails(ski, "", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	service.SetTrusted(true)
 	service.ConnectionStateDetail().SetState(api.ConnectionStateQueued)
 	hub.remoteServices = append(hub.remoteServices, service)
 
-	// A reconnect dial has already been scheduled for this SKI.
-	hub.connectionAttemptCounter[ski] = 0
-	hub.connectionDelayTimers[ski] = newConnectionDelayTimer(time.Hour, func() {})
+	present := []*api.MdnsEntry{{Name: "Service 1", Ski: ski, Identifier: "ID1"}}
+	absent := map[string]*api.MdnsEntry{}
 
-	// The remote was present in the previous mDNS snapshot ...
-	hub.knownMdnsEntries = []*api.MdnsEntry{{Name: "Service 1", Ski: ski, Identifier: "ID1"}}
+	// Repeat the appear-then-drop cycle so the guard reliably catches a regression
+	// instead of passing by chance on a single mDNS report.
+	for range 100 {
+		// A reconnect dial has been scheduled while the remote was present ...
+		hub.connectionAttemptCounter[ski] = 0
+		hub.storeConnectionDelayTimer(ski, newConnectionDelayTimer(time.Hour, func() {}))
+		hub.knownMdnsEntries = present
 
-	// ... but is absent from the next one for a moment.
-	hub.ReportMdnsEntries(map[string]*api.MdnsEntry{}, true)
+		// ... and the remote drops out of the next snapshot for a moment.
+		hub.ReportMdnsEntries(absent, true)
 
-	// The pending reconnect to the trusted device must survive the transient drop.
-	assert.Contains(t, hub.connectionDelayTimers, ski,
-		"pending reconnect timer for a trusted device must survive a transient mDNS drop")
-	assert.Contains(t, hub.connectionAttemptCounter, ski,
-		"connection attempt counter for a trusted device must survive a transient mDNS drop")
+		// The pending reconnect to the trusted device must survive the drop.
+		require.Contains(t, hub.connectionDelayTimers, ski,
+			"pending reconnect timer for a trusted device must survive a transient mDNS drop")
+		require.Contains(t, hub.connectionAttemptCounter, ski,
+			"connection attempt counter for a trusted device must survive a transient mDNS drop")
+	}
 }
 
 // Create tests the cover ReportMdnsEntries implementation

--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -574,7 +574,8 @@ func (h *Hub) OnPairingSuccess(remoteShipID, remoteFingerprint string) {
 
 // OnPairingFailure handles pairing validation failure (implements PairingHubInterface)
 func (h *Hub) OnPairingFailure(remoteShipID, remoteFingerprint string, reason error) {
-	// Use ServiceForFingerprint for consistent service management and SKI normalization
+	// Build a detached identity from the fingerprint/shipID only to report the
+	// failure; the hub's registered services are not looked up or modified.
 	service, err := api.NewServiceDetails("", remoteFingerprint, remoteShipID)
 	if err != nil {
 		logging.Log().Error("OnPairingFailure: invalid identifiers", "shipID", remoteShipID, "fingerprint", remoteFingerprint, "error", err)


### PR DESCRIPTION
Fixes #88.

`cleanupRemovedMdnsEntries` cancels the pending connection dial (delay timer + attempt counter) for every SKI missing from the latest mDNS snapshot. That is the intended resource saving for untrusted discovery (introduced in `67a274b`), but it also strands **trusted/paired** devices: when a trusted remote briefly stops announcing (e.g. during a restart) after the hub has already scheduled a dial, the next snapshot omits its SKI, the dial is cancelled, and the reconnect is not re-initiated until the device happens to re-announce.

Skip the cleanup for SKIs where `IsRemoteServiceForSKIPaired` is true, so a trusted device keeps retrying across a transient mDNS drop. Untrusted discovery attempts are still cleaned up as before.

### Test

Added `TestReportMdnsEntries_TrustedServiceSurvivesTransientMdnsDrop`: a trusted service with a scheduled reconnect, then an mDNS report that omits its SKI; the pending dial must survive.

Without the fix (test applied to unchanged `hub_mdns.go`) it fails, showing the dial being cancelled:

```
--- FAIL: TestReportMdnsEntries_TrustedServiceSurvivesTransientMdnsDrop
    map[string]*hub.connectionDelayTimer{} does not contain "0123...ffff"
      pending reconnect timer for a trusted device must survive a transient mDNS drop
    map[string]int{} does not contain "0123...ffff"
      connection attempt counter for a trusted device must survive a transient mDNS drop
```

With the fix it passes, and the full `hub` package is green.

### Context

Found via a flaky EEBus reconnect-after-restart in evcc (evcc-io/evcc#31534, evcc-io/evcc#31570), whose logs show the cancellation for a paired controlbox:

```
delaying connection to <ski> by 90ms to minimize double connection probability
hub: cleaning up connection attempts for SKI <ski> (no longer in mDNS)
```

This change removes that cause and substantially reduces the downstream flake, but does not fully eliminate it: a separate race, where a trusted device's re-announcement after restart is rejected as a replay and its trust is transiently not set when the cleanup runs, can still cancel the reconnect. That is out of scope here and worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

