### PR TITLE
hub: resolve and announce the actual bound port for a configured 0

### DIFF
--- a/api/mdns.go
+++ b/api/mdns.go
@@ -75,6 +75,10 @@ type MdnsInterface interface {
 	//   - autoAccept: true to enable auto-accept, false to require manual approval
 	SetAutoAccept(bool)
 
+	// SetPort updates the port announced via mDNS - e.g. once the websocket
+	// server resolves its actual bound port for a configured port of 0.
+	SetPort(port int)
+
 	// DeviceBrand returns the device brand for QR code generation and mDNS announcements.
 	// This is optional metadata that helps users identify the device.
 	DeviceBrand() string

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -49,7 +49,13 @@ type Hub struct {
 	// SKIs with an outgoing dial in flight but not yet registered
 	connectionsInitiating map[string]bool
 
-	port        int
+	// port is the configured port (0 means "let the OS assign one").
+	port int
+	// boundPort is the actual bound port, resolved once the websocket
+	// server starts listening; guarded by muxPort since Port() is exported.
+	boundPort int
+	muxPort   sync.RWMutex
+
 	certificate tls.Certificate
 
 	localService *api.ServiceDetails
@@ -151,6 +157,7 @@ func NewHub(hubReader api.HubReaderInterface,
 		connectionDelayTimers:       make(map[string]*connectionDelayTimer),
 		hubReader:                   hubReader,
 		port:                        port,
+		boundPort:                   port,
 		certificate:                 certificate,
 		localService:                localService,
 		mdns:                        mdns,

--- a/hub/hub_bound_port_test.go
+++ b/hub/hub_bound_port_test.go
@@ -1,0 +1,51 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/enbility/ship-go/api"
+	"github.com/enbility/ship-go/cert"
+	"github.com/enbility/ship-go/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestHub_BoundPort_ResolvesRealPortForEphemeralConfig: a hub configured with
+// port 0 must resolve and announce the real OS-assigned port, not 0.
+func TestHub_BoundPort_ResolvesRealPortForEphemeralConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	hubReader := mocks.NewMockHubReaderInterface(ctrl)
+	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+
+	var announcedPort int
+	mdnsService.EXPECT().SetPort(gomock.Any()).Do(func(port int) {
+		announcedPort = port
+	}).Times(1)
+	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mdnsService.EXPECT().Shutdown().Times(1)
+
+	certificate, err := cert.CreateCertificate("unit", "org", "DE", "CN")
+	require.NoError(t, err)
+	localService, err := api.NewServiceDetails("localSKI", "", "")
+	require.NoError(t, err)
+
+	hub, err := newTestHub(hubReader, mdnsService, 0, certificate, localService, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, hub.Port(), "Port() before Start() should reflect the configured port")
+
+	err = hub.Start()
+	require.NoError(t, err)
+	defer hub.Shutdown()
+
+	boundPort := hub.Port()
+	assert.NotZero(t, boundPort, "Port() after Start() must resolve a real OS-assigned port")
+	assert.Greater(t, boundPort, 0)
+	assert.LessOrEqual(t, boundPort, 65535)
+
+	assert.Equal(t, boundPort, announcedPort,
+		"mDNS must be told the actual bound port, not the configured 0")
+}

--- a/hub/hub_connections_server.go
+++ b/hub/hub_connections_server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -16,6 +17,15 @@ import (
 	"github.com/enbility/ship-go/ws"
 	"github.com/gorilla/websocket"
 )
+
+// Port returns the websocket server's actual bound port, resolved once
+// Start() has run - useful when the configured port was 0.
+func (h *Hub) Port() int {
+	h.muxPort.RLock()
+	defer h.muxPort.RUnlock()
+
+	return h.boundPort
+}
 
 // verifyPeerCertificate validates the peer certificate for WebSocket connections
 func (h *Hub) verifyPeerCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
@@ -54,6 +64,22 @@ func (h *Hub) startWebsocketServer() error {
 	addr := fmt.Sprintf(":%d", h.port)
 	logging.Log().Debug("starting websocket server on", addr)
 
+	// Listen synchronously so a bind failure (incl. port 0 -> OS-assigned)
+	// surfaces immediately and the actual bound port is known before mDNS starts.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("websocket server failed to start: %w", err)
+	}
+
+	boundPort := ln.Addr().(*net.TCPAddr).Port
+	h.muxPort.Lock()
+	h.boundPort = boundPort
+	h.muxPort.Unlock()
+	if h.port == 0 {
+		// OS-assigned port: mDNS must announce the real one, not 0.
+		h.mdns.SetPort(boundPort)
+	}
+
 	h.httpServer = &http.Server{
 		Addr:              addr,
 		Handler:           h,
@@ -70,7 +96,7 @@ func (h *Hub) startWebsocketServer() error {
 
 	serverStarted := h.serverStarted // capture for goroutine; prevents closing a replaced channel
 	go func() {
-		err := h.httpServer.ListenAndServeTLS("", "")
+		err := h.httpServer.ServeTLS(ln, "", "")
 		if err != nil && err != http.ErrServerClosed {
 			logging.Log().Error("websocket server error:", err)
 			h.serverStartErr = err

--- a/hub/hub_error_handling_test.go
+++ b/hub/hub_error_handling_test.go
@@ -51,6 +51,7 @@ func TestHub_Start_ReturnsError_WhenMdnsFails(t *testing.T) {
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
 
 	mdnsError := errors.New("mDNS startup failed")
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(mdnsError)
 
 	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
@@ -80,6 +81,7 @@ func TestHub_Start_Success(t *testing.T) {
 
 	hubReader := mocks.NewMockHubReaderInterface(ctrl)
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
 
 	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
@@ -224,6 +226,7 @@ func TestHub_HTTPServerShutdown_WithContext(t *testing.T) {
 
 	hubReader := mocks.NewMockHubReaderInterface(ctrl)
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
 	mdnsService.EXPECT().Shutdown()
 

--- a/hub/hub_lifecycle_test.go
+++ b/hub/hub_lifecycle_test.go
@@ -31,6 +31,7 @@ func TestHub_Lifecycle_DoubleStart_ReturnsError(t *testing.T) {
 
 	hubReader := mocks.NewMockHubReaderInterface(ctrl)
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	certificate, _ := cert.CreateCertificate("unit", "org", "DE", "CN")
@@ -67,6 +68,7 @@ func TestHub_Lifecycle_RestartAfterShutdown(t *testing.T) {
 
 	hubReader := mocks.NewMockHubReaderInterface(ctrl)
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	mdnsService.EXPECT().Shutdown().Times(2)
 
@@ -105,6 +107,7 @@ func TestHub_Lifecycle_ShutdownResetsState(t *testing.T) {
 
 	hubReader := mocks.NewMockHubReaderInterface(ctrl)
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	mdnsService.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mdnsService.EXPECT().Shutdown().Times(1)
 
@@ -137,6 +140,7 @@ func TestHub_Lifecycle_RetryAfterMdnsFailure(t *testing.T) {
 
 	hubReader := mocks.NewMockHubReaderInterface(ctrl)
 	mdnsService := mocks.NewMockMdnsInterface(ctrl)
+	mdnsService.EXPECT().SetPort(gomock.Any()).AnyTimes()
 
 	// First call fails, second succeeds
 	gomock.InOrder(

--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -792,6 +792,15 @@ func (m *MdnsManager) SetAutoAccept(accept bool) {
 	}
 }
 
+// SetPort updates the port announced via mDNS - e.g. once the websocket
+// server resolves its actual bound port for a configured port of 0.
+func (m *MdnsManager) SetPort(port int) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	m.port = port
+}
+
 // SetMdnsProvider sets the mDNS provider for the manager
 // mainly used for testing
 func (m *MdnsManager) SetMdnsProvider(provider api.MdnsProviderInterface) {

--- a/mocks/MdnsInterface.go
+++ b/mocks/MdnsInterface.go
@@ -375,6 +375,46 @@ func (_c *MdnsInterface_SetAutoAccept_Call) RunAndReturn(run func(b bool)) *Mdns
 	return _c
 }
 
+// SetPort provides a mock function for the type MdnsInterface
+func (_mock *MdnsInterface) SetPort(port int) {
+	_mock.Called(port)
+	return
+}
+
+// MdnsInterface_SetPort_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPort'
+type MdnsInterface_SetPort_Call struct {
+	*mock.Call
+}
+
+// SetPort is a helper method to define mock.On call
+//   - port int
+func (_e *MdnsInterface_Expecter) SetPort(port interface{}) *MdnsInterface_SetPort_Call {
+	return &MdnsInterface_SetPort_Call{Call: _e.mock.On("SetPort", port)}
+}
+
+func (_c *MdnsInterface_SetPort_Call) Run(run func(port int)) *MdnsInterface_SetPort_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MdnsInterface_SetPort_Call) Return() *MdnsInterface_SetPort_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MdnsInterface_SetPort_Call) RunAndReturn(run func(port int)) *MdnsInterface_SetPort_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Shutdown provides a mock function for the type MdnsInterface
 func (_mock *MdnsInterface) Shutdown() {
 	_mock.Called()

--- a/mocks/mockgen_api.go
+++ b/mocks/mockgen_api.go
@@ -147,6 +147,18 @@ func (mr *MockMdnsInterfaceMockRecorder) SetAutoAccept(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAutoAccept", reflect.TypeOf((*MockMdnsInterface)(nil).SetAutoAccept), arg0)
 }
 
+// SetPort mocks base method.
+func (m *MockMdnsInterface) SetPort(arg0 int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPort", arg0)
+}
+
+// SetPort indicates an expected call of SetPort.
+func (mr *MockMdnsInterfaceMockRecorder) SetPort(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPort", reflect.TypeOf((*MockMdnsInterface)(nil).SetPort), arg0)
+}
+
 // Shutdown mocks base method.
 func (m *MockMdnsInterface) Shutdown() {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
`startWebsocketServer` bound the websocket listener implicitly inside `ListenAndServeTLS`, so a configured port of 0 (OS-assigned) was never resolvable - `Hub` had no way to report the real port, and mDNS kept announcing the literal configured value, which `mdns.go`'s own validation already rejects as invalid (`port <= 0`).

Listen synchronously instead, so a bind failure surfaces immediately (as a bonus, this also removes the pre-existing 100ms poll-and-hope window in `Start()` for detecting bind failures) and the real bound port is known before mDNS starts.

- `Hub.Port()` exposes the actual bound port.
- `MdnsInterface.SetPort` updates the announced port when the configured port was 0; fixed-port callers are unaffected (the call is gated on `h.port == 0`, so no existing mock expectations needed touching beyond the port-0 test paths).

### Test

`TestHub_BoundPort_ResolvesRealPortForEphemeralConfig` asserts `Port()` resolves a real port and that `SetPort` is called with that exact value.

Verified both falsification angles:
- Without `Port()`/`SetPort` at all: compile error (not by itself meaningful).
- With `Port()` present but the `SetPort` call removed: the test still compiles and runs, and fails on a live assertion (`expected: <real port>, actual: 0` - "mDNS must be told the actual bound port, not the configured 0").

Full suite green (`go build/vet/test ./...`), including the pre-existing gomock-based `hub` package tests that construct a hub with port 0 (updated with `SetPort` expectations where they exercise a real `Start()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

