### PR TITLE
hub: remove unused announcement cancel context

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -32,10 +32,9 @@ var connectionInitiationDelayTimeRanges = []connectionInitiationDelayTimeRange{
 
 // announcementState tracks the state of an active announcement to a target device
 type announcementState struct {
-	target     api.PairingTarget
-	announcer  api.PairingAnnouncerInterface
-	startTime  time.Time
-	cancelFunc context.CancelFunc
+	target    api.PairingTarget
+	announcer api.PairingAnnouncerInterface
+	startTime time.Time
 }
 
 // handling the server and all connections to remote services
@@ -281,9 +280,6 @@ func (h *Hub) Shutdown() {
 	h.muxAnnouncements.Lock()
 	for shipID, state := range h.activeAnnouncements {
 		logging.Log().Debug("stopping announcement to", shipID, "during shutdown")
-		if state.cancelFunc != nil {
-			state.cancelFunc()
-		}
 		if state.announcer != nil {
 			_ = state.announcer.StopAnnouncement()
 		}

--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
@@ -403,15 +402,11 @@ func (h *Hub) StartAnnouncementTo(target api.PairingTarget) error {
 		return fmt.Errorf("failed to create pairing announcer")
 	}
 
-	// Create context for this announcement (child of Hub's pairing context)
-	_, cancel := context.WithCancel(h.pairingCtx)
-
 	// Create announcement state
 	state := announcementState{
-		target:     target,
-		announcer:  announcer,
-		startTime:  time.Now(),
-		cancelFunc: cancel,
+		target:    target,
+		announcer: announcer,
+		startTime: time.Now(),
 	}
 
 	// Enable the announcer with the target's secret
@@ -456,11 +451,6 @@ func (h *Hub) StopAnnouncementTo(shipID string) error {
 	state, exists := h.activeAnnouncements[shipID]
 	if !exists {
 		return fmt.Errorf("no active announcement for device: %s", shipID)
-	}
-
-	// Cancel the announcement context
-	if state.cancelFunc != nil {
-		state.cancelFunc()
 	}
 
 	// Stop the announcer


### PR DESCRIPTION
The context derived via `context.WithCancel(h.pairingCtx)` in `StartAnnouncementTo` was discarded immediately (assigned to `_`), so its `Done()` channel was never observed anywhere. The stored `cancelFunc` only released that dead context's bookkeeping in the parent's child list; the real teardown already happens via `announcer.StopAnnouncement()`, called right alongside every `cancelFunc()` call (in both `StopAnnouncementTo` and `Shutdown`). Dropped the context and the `cancelFunc` field entirely.

fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)