### PR TITLE
fix(mdns): handle service type comparison case-insensitively

### DIFF
--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -930,7 +930,7 @@ func (m *MdnsManager) UnregisterPairingCallback() {
 
 // detectServiceType determines the service type based on the serviceType parameter
 func (m *MdnsManager) detectServiceType(serviceType string) ServiceType {
-	// Check the serviceType parameter with exact matching
+	// Compare case insensitively per RFC 6763
 	switch strings.ToLower(serviceType) {
 	case shipPairingZeroConfServiceType: // "_shippairing._tcp"
 		return ServiceTypeShipPairing

--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -51,9 +51,9 @@ func DefaultProviderFactory() *ProviderFactory {
 // The logicalID (the map key in announcedPairings) is stable and returned to callers.
 // providerID is transient and updated transparently when interfaces change.
 type announcedPairing struct {
-	serviceName string               // mDNS service name — stable across re-announcements
-	txtRecord   *api.ShipPairingTXT  // TXT record data
-	providerID  string               // current provider-side instance ID (changes on re-announcement)
+	serviceName string              // mDNS service name — stable across re-announcements
+	txtRecord   *api.ShipPairingTXT // TXT record data
+	providerID  string              // current provider-side instance ID (changes on re-announcement)
 }
 
 type MdnsManager struct {
@@ -105,7 +105,7 @@ type MdnsManager struct {
 	// created during re-announcement. This keeps caller-held IDs valid indefinitely.
 	announcedPairings    map[string]*announcedPairing
 	announcedPairingsMux sync.RWMutex
-	instanceCounter       int // monotonic counter for stable logical ID and service name generation
+	instanceCounter      int // monotonic counter for stable logical ID and service name generation
 
 	// the currently available mDNS entries with the serviceName as the key in the map
 	entries map[string]*api.MdnsEntry
@@ -188,7 +188,7 @@ func NewMDNS(
 		entries:           make(map[string]*api.MdnsEntry),
 		pairingEntries:    make(map[string]*api.ShipPairingTXT),
 		announcedPairings: make(map[string]*announcedPairing),
-		instanceCounter:    0,
+		instanceCounter:   0,
 		providerFactory:   DefaultProviderFactory(),
 	}
 
@@ -931,7 +931,7 @@ func (m *MdnsManager) UnregisterPairingCallback() {
 // detectServiceType determines the service type based on the serviceType parameter
 func (m *MdnsManager) detectServiceType(serviceType string) ServiceType {
 	// Check the serviceType parameter with exact matching
-	switch serviceType {
+	switch strings.ToLower(serviceType) {
 	case shipPairingZeroConfServiceType: // "_shippairing._tcp"
 		return ServiceTypeShipPairing
 	case shipZeroConfServiceType: // "_ship._tcp"

--- a/mdns/mdns_service_detection_test.go
+++ b/mdns/mdns_service_detection_test.go
@@ -44,8 +44,33 @@ func (s *ServiceDetectionSuite) Test_detectServiceType() {
 			expectedType: ServiceTypeShipPairing,
 		},
 		{
+			name:         "detects SHIP service with uppercase",
+			serviceType:  "_SHIP._TCP",
+			expectedType: ServiceTypeShip,
+		},
+		{
+			name:         "detects SHIP service with mixed case",
+			serviceType:  "_Ship._Tcp",
+			expectedType: ServiceTypeShip,
+		},
+		{
+			name:         "detects SHIP pairing service with uppercase",
+			serviceType:  "_SHIPPAIRING._TCP",
+			expectedType: ServiceTypeShipPairing,
+		},
+		{
+			name:         "detects SHIP pairing service with mixed case",
+			serviceType:  "_ShipPairing._Tcp",
+			expectedType: ServiceTypeShipPairing,
+		},
+		{
 			name:         "returns unknown for unrecognized service",
 			serviceType:  "_http._tcp",
+			expectedType: ServiceTypeUnknown,
+		},
+		{
+			name:         "returns unknown for unrecognized service regardless of case",
+			serviceType:  "_HTTP._TCP",
 			expectedType: ServiceTypeUnknown,
 		},
 		{


### PR DESCRIPTION
## Problem
`detectServiceType` compares mDNS service types case-sensitively. Some SHIP 
implementations (e.g. Theben Mehrwertmodul) publish on `_shipPairing._tcp` (camelCase) instead 
of `_shippairing._tcp` (lowercase).

While the SHIP spec expects lowercase service types, [RFC 6763 (DNS-Based 
Service Discovery)](https://www.rfc-editor.org/rfc/rfc6763.html) states that 
DNS name comparisons — including service type strings — are case-insensitive. 
Because of this, devices using camelCase service types are currently not 
detected correctly.

## Solution
Make the service type check in `detectServiceType` case-insensitive, in line 
with RFC 6763, so devices publishing non-lowercase (but otherwise valid) 
service types are still correctly recognized.