### PR TITLE
test: annotate tests with covered SHIP test-spec cases

### DIFF
--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -167,6 +167,8 @@ func (c *CertSuite) Test_SkiFromCertificate_NonECDSAKey() {
 }
 
 // Test_SkiFromCertificate_SKIMismatch tests SKI validation errors
+// TC_SHIP_SEC_001: DUT rejects a spoofed certificate whose SKI != SHA-1(public key) (no prior pairing).
+// TC_SHIP_SEC_002: same SKI-mismatch detection applies regardless of the SKI being known from a prior pairing.
 func (c *CertSuite) Test_SkiFromCertificate_SKIMismatch() {
 	// Create a valid ECDSA key
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/hub/hub_connections_client_coverage_test.go
+++ b/hub/hub_connections_client_coverage_test.go
@@ -891,6 +891,7 @@ func (s *HubConnectionsClientCoverageSuite) createDirectTestCertificate(expiryTi
 
 // Test_KeepThisConnection_DirectTest tests the keepThisConnection function directly
 // to ensure proper coverage of the double connection prevention logic
+// TC_SHIP_ROLE_003: on a double connection the node with the larger SKI keeps the connection (server & client roles), per SHIP-TS-ROLE-01.
 func (s *HubConnectionsClientCoverageSuite) Test_KeepThisConnection_DirectTest() {
 	// Test case 1: No existing connection - should return true
 	s.Run("no_existing_connection", func() {

--- a/ship/connection_messaging_coverage_test.go
+++ b/ship/connection_messaging_coverage_test.go
@@ -148,10 +148,12 @@ func (s *ConnectionMessagingCoverageSuite) Test_HandleIncomingWebsocketMessage_E
 		message []byte
 	}{
 		{
+			// TC_SHIP_MSG_002: DUT silently handles a SHIP message with an unknown MessageType (0xFF) without closing/panicking.
 			name:    "invalid_utf8",
 			message: []byte{0xFF, 0xFF},
 		},
 		{
+			// TC_SHIP_MSG_001: DUT silently handles a SHIP message with only a MessageType and empty MessageValue.
 			name:    "very_short",
 			message: []byte{0},
 		},

--- a/ship/hs_access_test.go
+++ b/ship/hs_access_test.go
@@ -112,6 +112,7 @@ func (s *AccessSuite) Test_Init_SendError() {
 	assert.Equal(s.T(), false, s.sut.handshakeTimerRunning)
 }
 
+// TC_SHIP_AM_001: DUT replies to an access-methods request with its own access methods (accessMethods.id = own SHIP ID).
 func (s *AccessSuite) Test_Request() {
 	s.sut.setState(model.SmeAccessMethodsRequest, nil)
 

--- a/ship/hs_hello_server_test.go
+++ b/ship/hs_hello_server_test.go
@@ -124,6 +124,7 @@ func (s *HelloSuite) Test_ReadyListen_Init() {
 	assert.Equal(s.T(), true, s.sut.getHandshakeTimerRunning())
 }
 
+// TC_SHIP_HELLO_001: DUT processes a valid "ready" hello and proceeds into the protocol handshake.
 func (s *HelloSuite) Test_ReadyListen_Ok() {
 	s.sut.setState(model.SmeHelloStateReadyInit, nil) // inits the timer
 	s.sut.setState(model.SmeHelloStateReadyListen, nil)
@@ -144,6 +145,7 @@ func (s *HelloSuite) Test_ReadyListen_Ok() {
 	assert.Equal(s.T(), model.SmeProtHStateServerListenProposal, s.sut.getState())
 }
 
+// TC_SHIP_HELLO_003: DUT aborts hello when the Wait-For-Ready timer expires (timeout).
 func (s *HelloSuite) Test_ReadyListen_Timeout() {
 	s.sut.setState(model.SmeHelloStateReadyInit, nil) // inits the timer
 	s.sut.setState(model.SmeHelloStateReadyListen, nil)
@@ -155,6 +157,7 @@ func (s *HelloSuite) Test_ReadyListen_Timeout() {
 	assert.NotNil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_HELLO_004: DUT ignores a "pending" update without prolongationRequest while in "ready" state.
 func (s *HelloSuite) Test_ReadyListen_Ignore() {
 	s.sut.setState(model.SmeHelloStateReadyInit, nil) // inits the timer
 	s.sut.setState(model.SmeHelloStateReadyListen, nil)
@@ -194,6 +197,7 @@ func (s *HelloSuite) Test_ReadyListen_Ignore_Invalid() {
 	assert.Equal(s.T(), model.SmeHelloStateReadyListen, s.sut.getState())
 }
 
+// TC_SHIP_HELLO_002: DUT accepts an incoming prolongation request and re-arms the Wait-For-Ready timer.
 func (s *HelloSuite) Test_ReadyListen_Prolongation() {
 	s.sut.setState(model.SmeHelloStateReadyInit, nil) // inits the timer
 	s.sut.setState(model.SmeHelloStateReadyListen, nil)

--- a/ship/hs_init_client_test.go
+++ b/ship/hs_init_client_test.go
@@ -83,6 +83,7 @@ func (s *InitClientSuite) Test_Init() {
 	assert.Equal(s.T(), model.CmiStateInitStart, s.sut.getState())
 }
 
+// TC_SHIP_ROLE_002: DUT acting as SME client sends the CMI init and enters CMI client-wait.
 func (s *InitClientSuite) Test_Start() {
 	s.sut.setState(model.CmiStateInitStart, nil)
 
@@ -104,6 +105,7 @@ func (s *InitClientSuite) Test_ClientWait() {
 	assert.NotNil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_CMI_004: DUT as client closes the connection when the CmiTimeout expires without a CMI message.
 func (s *InitClientSuite) Test_ClientWait_Timeout() {
 	s.mockShipInfo.EXPECT().HandleConnectionClosed(mock.Anything, mock.Anything).Return()
 
@@ -115,6 +117,7 @@ func (s *InitClientSuite) Test_ClientWait_Timeout() {
 	assert.Nil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_CMI_002: DUT as client closes the connection on an invalid CMI MessageType (!= 0).
 func (s *InitClientSuite) Test_ClientWait_InvalidMsgType() {
 	s.sut.setState(model.CmiStateClientWait, nil)
 
@@ -124,6 +127,7 @@ func (s *InitClientSuite) Test_ClientWait_InvalidMsgType() {
 	assert.Nil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_CMI_006: DUT as client closes the connection on an invalid CmiHead/MessageValue (> 0).
 func (s *InitClientSuite) Test_ClientWait_InvalidData() {
 	s.sut.setState(model.CmiStateClientWait, nil)
 

--- a/ship/hs_init_server_test.go
+++ b/ship/hs_init_server_test.go
@@ -83,6 +83,7 @@ func (s *InitServerSuite) Test_Init() {
 	assert.Equal(s.T(), model.CmiStateInitStart, s.sut.getState())
 }
 
+// TC_SHIP_ROLE_001: DUT acting as SME server enters CMI server-wait after init.
 func (s *InitServerSuite) Test_Start() {
 	s.sut.setState(model.CmiStateInitStart, nil)
 
@@ -120,6 +121,7 @@ func (s *InitServerSuite) Test_ServerWait_InvalidData() {
 	assert.Nil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_CMI_003: DUT as server closes the connection when the CmiTimeout expires without a CMI message.
 func (s *InitServerSuite) Test_ServerWait_Timeout() {
 	s.sut.setState(model.CmiStateServerWait, nil)
 

--- a/ship/hs_pin_test.go
+++ b/ship/hs_pin_test.go
@@ -115,6 +115,7 @@ func (s *PinSuite) Test_CheckListen_Failure() {
 	assert.Equal(s.T(), model.SmeStateError, s.sut.getState())
 }
 
+// TC_SHIP_PIN_001: DUT accepts pin state "none" and advances to the access-methods request.
 func (s *PinSuite) Test_CheckListen_None() {
 	s.sut.setState(model.SmePinStateCheckListen, nil)
 

--- a/ship/hs_prot_client_test.go
+++ b/ship/hs_prot_client_test.go
@@ -89,6 +89,7 @@ func (s *ProClientSuite) Test_Init() {
 	assert.NotNil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_PROT_002: DUT as client accepts the server's select and confirms the JSON-UTF8 format.
 func (s *ProClientSuite) Test_ListenChoice() {
 	s.sut.setState(model.SmeProtHStateClientListenChoice, nil)
 

--- a/ship/hs_prot_server_test.go
+++ b/ship/hs_prot_server_test.go
@@ -91,6 +91,7 @@ func (s *ProServerSuite) Test_Init() {
 	assert.Nil(s.T(), s.lastMessage())
 }
 
+// TC_SHIP_PROT_001: DUT as server accepts the announceMax proposal and selects the JSON-UTF8 format.
 func (s *ProServerSuite) Test_ListenProposal() {
 	s.sut.setState(model.SmeProtHStateServerListenProposal, nil)
 


### PR DESCRIPTION
Makes SHIP High-Level Test Specification (V1.0.0) coverage explicit: adds a one-line `// TC_SHIP_...` reference comment to each existing test that already exercises a conformant test-case requirement. **Comment-only** — no production code, test logic, or assertions changed; `./ship ./cert ./hub` stay green.

Contributes to #95 (SHIP TestSpecification compliance) by making the "already covered" cases traceable in-code.

## Annotated

| TC | Test |
|----|------|
| AM_001 | `ship/hs_access_test.go` `Test_Request` |
| CMI_002 | `ship/hs_init_client_test.go` `Test_ClientWait_InvalidMsgType` |
| CMI_003 | `ship/hs_init_server_test.go` `Test_ServerWait_Timeout` |
| CMI_004 | `ship/hs_init_client_test.go` `Test_ClientWait_Timeout` |
| CMI_006 | `ship/hs_init_client_test.go` `Test_ClientWait_InvalidData` |
| HELLO_001-004 | `ship/hs_hello_server_test.go` `Test_ReadyListen_Ok/Prolongation/Timeout/Ignore` |
| MSG_001/002 | `ship/connection_messaging_coverage_test.go` `Test_HandleIncomingWebsocketMessage_EdgeCases` |
| PIN_001 | `ship/hs_pin_test.go` `Test_CheckListen_None` |
| PROT_001 | `ship/hs_prot_server_test.go` `Test_ListenProposal` |
| PROT_002 | `ship/hs_prot_client_test.go` `Test_ListenChoice` |
| ROLE_001 | `ship/hs_init_server_test.go` `Test_Start` |
| ROLE_002 | `ship/hs_init_client_test.go` `Test_Start` |
| ROLE_003 | `hub/hub_connections_client_coverage_test.go` `Test_KeepThisConnection_DirectTest` |
| SEC_001/002 | `cert/cert_test.go` `Test_SkiFromCertificate_SKIMismatch` |

Notes: SEC_001/002 both reduce to the SKI≠SHA-1(pubkey) rejection in `SkiFromCertificate` (stacked on the one mismatch test). AM_001's covering test drives `handleAccessMethodsRequest` (which sets `accessMethods.id` = own SHIP id) but asserts a reply is sent rather than the exact id value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
