### PR TITLE
chore: drop redundant length guard around range

### DIFF
--- a/ship/connection_race_test.go
+++ b/ship/connection_race_test.go
@@ -132,11 +132,9 @@ func TestApprovePendingHandshake_RaceCondition(t *testing.T) {
 	// Verify HandleConnectionClosed was called if abort succeeded
 	// Note: Due to timing, HandleConnectionClosed might not always be called immediately
 	closedCalls := safeTracker.GetConnectionClosedCalls()
-	if len(closedCalls) > 0 {
-		// If we have close calls, verify the remote SKI is correct
-		for _, call := range closedCalls {
-			assert.Equal(t, "remote-ski", call.RemoteSKI, "Remote SKI should match")
-		}
+	// If we have close calls, verify the remote SKI is correct
+	for _, call := range closedCalls {
+		assert.Equal(t, "remote-ski", call.RemoteSKI, "Remote SKI should match")
 	}
 
 	// Verify handshake state updates were recorded


### PR DESCRIPTION
Ranging over an empty slice is a no-op, so the surrounding length guard adds nothing.

- `ship/connection_race_test.go` — `if len(closedCalls) > 0 {` around a `range closedCalls`

Found with an AST pass over the whole repo rather than a text search. This is the only occurrence in ship-go; the similar-looking checks elsewhere (e.g. `service == nil || len(service.Text) == 0`, `r.TLS == nil || len(r.TLS.PeerCertificates) == 0`) are not redundant, since the nil check guards a dereference and the `len()` applies to a different value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
