### PR TITLE
feat(pairing): expose pairing listener state via public getters

### DIFF
--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -249,6 +249,14 @@ func (h *Hub) PairingService() api.ShipPairingServiceInterface {
 	return h.pairingService
 }
 
+// PairingListener returns the active devA pairing listener, if any.
+func (h *Hub) PairingListener() api.PairingListenerInterface {
+	h.muxPairingListener.RLock()
+	defer h.muxPairingListener.RUnlock()
+
+	return h.activePairingListener
+}
+
 // SetPairingService configures the optional pairing service (called during Hub construction)
 func (h *Hub) SetPairingService(service api.ShipPairingServiceInterface) error {
 	h.muxPairing.Lock()

--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -309,6 +309,15 @@ func (m *MdnsManager) setReportInterface(report api.MdnsReportInterface) {
 	m.report = report
 }
 
+// ConnectionsHub returns the SHIP connections hub registered as mDNS report callback.
+// Available after Hub.Start() has invoked MdnsInterface.Start.
+func (m *MdnsManager) ConnectionsHub() api.HubInterface {
+	if hub, ok := m.reportInterface().(api.HubInterface); ok {
+		return hub
+	}
+	return nil
+}
+
 func (m *MdnsManager) Start(pairingMode api.PairingMode, cb api.MdnsReportInterface) error {
 	// Always update the callback, even on subsequent calls
 	m.setReportInterface(cb)

--- a/pairing/service.go
+++ b/pairing/service.go
@@ -125,6 +125,14 @@ func (s *Service) IsServiceRunning() bool {
 	return s.running
 }
 
+// Listener returns the active pairing listener instance, if any.
+func (s *Service) Listener() api.PairingListenerInterface {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	return s.listener
+}
+
 // CreateAnnouncer creates a configured announcer component
 func (s *Service) CreateAnnouncer() api.PairingAnnouncerInterface {
 	s.mux.RLock()

--- a/pairing/service_test.go
+++ b/pairing/service_test.go
@@ -83,6 +83,14 @@ func (suite *ServiceTestSuite) TestServiceLifecycle() {
 	assert.False(suite.T(), status)
 }
 
+func (suite *ServiceTestSuite) TestServiceListenerGetter() {
+	require.Nil(suite.T(), suite.sut.Listener())
+
+	listener := suite.sut.CreateListener()
+	require.NotNil(suite.T(), listener)
+	assert.Same(suite.T(), listener, suite.sut.Listener())
+}
+
 func (suite *ServiceTestSuite) TestShutdown_ServiceStateOnly() {
 	// Test that Service shutdown only manages Service state (stateless factory pattern)
 


### PR DESCRIPTION
## What

Three additive getters that expose the pairing listener state, plus a test. No behaviour change, no existing signature touched:

- `pairing.Service.Listener() api.PairingListenerInterface`
- `hub.Hub.PairingListener() api.PairingListenerInterface`
- `mdns.MdnsManager.ConnectionsHub() api.HubInterface`

## Why

We are building a devA implementation on top of ship-go and need to report, in the device's diagnostics endpoint, whether addCu processing is currently active — the state that `PairingListener.GetListenerStatus()` already tracks (`Active`, `RequestsSeen`, `LastRequest`, `Error`).

`GetListenerStatus()` is public, but the listener instance itself is only reachable through unexported fields (`Service.listener`, `Hub.activePairingListener`, `MdnsManager.reportInterface()`), so an application cannot get to it.

Without these getters the only option we found was reflection into unexported fields via `unsafe`. That works, but it binds an application on a field device to the internal layout of the library — we did not want to ship that, hence this PR.

## Why it matters in practice

The deactivation of addCu processing after a successful pairing (spec section 4.3) is invisible from the outside. During conformance measurements we repeatedly probed a device that had silently stopped processing requests, and four test cases produced meaningless results before we understood why. An application that can read `Active` can simply wait instead.

## Notes

- Getters only, all guarded by the existing mutexes.
- `pairing/service_test.go`: added `TestServiceListenerGetter` (nil before `CreateListener()`, same instance afterwards).
- Based on `dev`.
