### PR TITLE
fix(hub): reset connection backoff when a remote service is registered

### DIFF
--- a/hub/hub_connections_retry_test.go
+++ b/hub/hub_connections_retry_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"testing"
+	"time"
 
 	"github.com/enbility/ship-go/api"
 	"github.com/enbility/ship-go/cert"
@@ -109,4 +110,25 @@ func (s *HubConnectionsRetrySuite) Test_ConnectionAttemptRunning() {
 	s.sut.setConnectionAttemptRunning(s.remoteSki, false)
 	status = s.sut.isConnectionAttemptRunning(s.remoteSki)
 	assert.Equal(s.T(), false, status)
+}
+
+func (s *HubConnectionsRetrySuite) Test_RegisterRemoteServiceResetsBackoff() {
+	s.sut.hasStarted = true
+
+	// simulate an accumulated backoff with a pending delay timer
+	s.sut.increaseConnectionAttemptCounter(s.remoteSki)
+	s.sut.increaseConnectionAttemptCounter(s.remoteSki)
+	s.sut.setConnectionAttemptRunning(s.remoteSki, true)
+	s.sut.storeConnectionDelayTimer(s.remoteSki, newConnectionDelayTimer(time.Minute, func() {}))
+
+	s.sut.RegisterRemoteService(api.NewServiceIdentity(s.remoteSki, "", ""))
+
+	_, exists := s.sut.getCurrentConnectionAttemptCounter(s.remoteSki)
+	assert.False(s.T(), exists)
+	assert.False(s.T(), s.sut.isConnectionAttemptRunning(s.remoteSki))
+
+	s.sut.muxTimers.Lock()
+	_, timerExists := s.sut.connectionDelayTimers[s.remoteSki]
+	s.sut.muxTimers.Unlock()
+	assert.False(s.T(), timerExists)
 }

--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -143,6 +143,12 @@ func (h *Hub) RegisterRemoteService(identity api.ServiceIdentity) {
 		return
 	}
 
+	// Registering expresses fresh connection intent, so drop an accumulated
+	// retry backoff: the delay ranges grow to 10-20s and would otherwise defer
+	// the attempt far beyond what a caller waiting for the connection expects.
+	h.cancelConnectionDelayTimer(identity.SKI)
+	h.removeConnectionAttemptCounter(identity.SKI)
+
 	// Pairing spec §4.3: registering trust in an addCu device expresses the
 	// pairing intent, so processing of addCu-requests must deactivate now —
 	// not only once the connection completes (HandleShipHandshakeStateUpdate).
@@ -199,6 +205,7 @@ func (h *Hub) UnregisterRemoteService(identity api.ServiceIdentity) {
 		}
 	}
 
+	h.cancelConnectionDelayTimer(identity.SKI)
 	h.removeConnectionAttemptCounter(identity.SKI)
 
 	// Convert ServiceIdentity to ServiceDetails for service-based lookup


### PR DESCRIPTION
`RegisterRemoteService` expresses fresh connection intent, but the per-SKI retry state survived it: the attempt counter kept whatever level earlier failures had reached, so the next attempt was deferred by the `10-20s` range even though the caller had just asked for the connection.

A pending delay timer made it worse. `UnregisterRemoteService` removed the attempt counter but left the timer in place, and with it `connectionAttemptRunning` set to `true`. `coordinateConnectionInitations` returns early in that state, so the following registration's attempt was swallowed until the stale timer fired.

This is visible from an application waiting for a device connection: evcc's device configuration test aborts after a fixed timeout, and once the backoff had escalated it never saw a connection again ([evcc-io/evcc#25058](https://github.com/evcc-io/evcc/discussions/25058#discussioncomment-18123767) — delays of 14.2s, 12.9s and 10.2s against a 10s window, with the connection succeeding immediately after a restart).

Changes:

- `RegisterRemoteService` cancels a pending delay timer and drops the attempt counter before triggering discovery
- `UnregisterRemoteService` cancels the delay timer as well, so it no longer leaves the attempt flag set

The automatic retry behaviour on repeated failures is unchanged — only an explicit register/unregister resets it.

Test `Test_RegisterRemoteServiceResetsBackoff` covers the reset; it fails on `dev` without the change. Full `hub` package passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
