### PR TITLE
ci: give the race detection job a workable timeout

### DIFF
--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -128,7 +128,8 @@ jobs:
       - name: Run Race Detection Tests (GOMAXPROCS=${{ matrix.gomaxprocs }})
         run: |
           echo "Running race detection with GOMAXPROCS=${{ matrix.gomaxprocs }}..."
-          go test -race -timeout=90s -count=3 ./ship ./hub
+          # -timeout is per test binary: ./hub needs ~30s per -race run, so -count=3 needs >90s
+          go test -race -timeout=300s -count=3 ./ship ./hub
         env:
           GOMAXPROCS: ${{ matrix.gomaxprocs }}
 


### PR DESCRIPTION
`go test -race -timeout=90s -count=3 ./ship ./hub` gives **each test binary** a 90s budget. `./hub` needs ~30s per `-race` run, so `-count=3` lands at ~88s locally — inside the budget, with no headroom at all:

```
ok  github.com/enbility/ship-go/ship  29.031s
ok  github.com/enbility/ship-go/hub   88.360s
```

On a GitHub runner it tips over and the job fails with `panic: test timed out after 1m30s`. The dump reads like a deadlock, but the goroutines it names are ordinary: the `running tests:` header shows only `TestHubConnectionsServerSuite` (2s in), and the two live goroutines are a `time.Sleep` inside the test and the 500ms delayed-callback goroutine from `HandleShipHandshakeStateUpdate`. Nothing is stuck — the clock ran out mid-suite.

This is not tied to any one branch. The same job has been flapping on `dev` for weeks; run 33413520498 (PR #109, an mdns-only change) is just the latest to hit it.

### Change

Raise the timeout on that one step to 300s. Still well inside the job's `timeout-minutes: 15`. The other `-timeout=90s` steps in the file are `-count=1` or `-run`-filtered subsets and have plenty of margin.

Not addressed here: `./hub` spending ~13s of its 30s in `TestHandleShipHandshakeStateUpdateTestSuite`, where ~25 tests each wait out the hardcoded 500ms delay in `hub_shipconnection.go`. Making that delay injectable would cut the runtime by a third — worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
