### PR TITLE
fix(hub): group SKI in blocks of 4 hex digits in QR codes

### DIFF
--- a/hub/hub_pairing.go
+++ b/hub/hub_pairing.go
@@ -661,7 +661,7 @@ func (h *Hub) GeneratePairingQR() (string, error) {
 
 // generateStandardShipQR generates the standard SHIP QR format
 func (h *Hub) generateStandardShipQR() (string, error) {
-	ski := h.localService.SKI()
+	ski := formatSKIForQRCode(h.localService.SKI())
 	identifier := h.localService.ShipID()
 	optionals := h.buildOptionalMetadata()
 
@@ -686,7 +686,7 @@ func (h *Hub) generatePairingServiceQR(secret api.PairingSecret) (string, error)
 	}
 
 	// Get required fields
-	ski := h.localService.SKI()
+	ski := formatSKIForQRCode(h.localService.SKI())
 	shipID := h.localService.ShipID()
 
 	// Encode secret as uppercase hex
@@ -729,6 +729,22 @@ func (h *Hub) buildOptionalMetadata() string {
 	}
 
 	return optionals
+}
+
+// formatSKIForQRCode inserts a space every 4 characters, as required by SHIP Spec 1.1.0
+// section 12.7 (see also section 12.2): the SKI is encoded as a non-prefixed hexadecimal
+// string with an additional space every 4 hexadecimal digits. The case of the input is
+// preserved, as the spec allows upper or lower case letters.
+func formatSKIForQRCode(ski string) string {
+	var result strings.Builder
+	for i, char := range ski {
+		if i > 0 && i%4 == 0 {
+			result.WriteByte(' ')
+		}
+		result.WriteRune(char)
+	}
+
+	return result.String()
 }
 
 // safeQRCodeKeyValue returns a safe to use key value pair for the QR code text in the proper format

--- a/hub/hub_pairing_test.go
+++ b/hub/hub_pairing_test.go
@@ -1602,7 +1602,7 @@ func (suite *HubPairingQRTestSuite) TestGeneratePairingQR_ValidSecret() {
 	assert.True(suite.T(), strings.HasSuffix(qrString, "ENDSHIP;"), "QR should end with ENDSHIP;")
 
 	// Verify contains required fields
-	assert.Contains(suite.T(), qrString, "SKI:hubtestski;")
+	assert.Contains(suite.T(), qrString, "SKI:hubt ests ki;")
 	assert.Contains(suite.T(), qrString, "ID:i:123_u:hub-test;")
 
 	// Verify contains FPH256 field (SHA-256 fingerprint should be 64 uppercase hex chars)
@@ -1687,7 +1687,7 @@ func (suite *HubPairingQRTestSuite) TestGeneratePairingQR_EmptySecret() {
 	assert.NotEmpty(suite.T(), qrString)
 	assert.True(suite.T(), strings.HasPrefix(qrString, "SHIP;"), "Should start with SHIP;")
 	assert.True(suite.T(), strings.HasSuffix(qrString, "ENDSHIP;"), "Should end with ENDSHIP;")
-	assert.Contains(suite.T(), qrString, "SKI:hubtestski", "Should contain the SKI")
+	assert.Contains(suite.T(), qrString, "SKI:hubt ests ki", "Should contain the SKI")
 	assert.Contains(suite.T(), qrString, "ID:i:123_u:hub-test", "Should contain the ship ID")
 	assert.NotContains(suite.T(), qrString, "SPSEC")
 }
@@ -1706,7 +1706,7 @@ func (suite *HubPairingQRTestSuite) TestGeneratePairingQR_NilSecret() {
 	assert.NotEmpty(suite.T(), qrString)
 	assert.True(suite.T(), strings.HasPrefix(qrString, "SHIP;"), "Should start with SHIP;")
 	assert.True(suite.T(), strings.HasSuffix(qrString, "ENDSHIP;"), "Should end with ENDSHIP;")
-	assert.Contains(suite.T(), qrString, "SKI:hubtestski", "Should contain the SKI")
+	assert.Contains(suite.T(), qrString, "SKI:hubt ests ki", "Should contain the SKI")
 	assert.Contains(suite.T(), qrString, "ID:i:123_u:hub-test", "Should contain the ship ID")
 	assert.NotContains(suite.T(), qrString, "SPSEC")
 }
@@ -1745,6 +1745,40 @@ func (suite *HubPairingQRTestSuite) TestGeneratePairingQR_InvalidCertificate() {
 	assert.Error(suite.T(), err)
 	assert.Empty(suite.T(), qrString)
 	assert.True(suite.T(), errors.Is(err, api.ErrInvalidCertificate), "Should return ErrInvalidCertificate for invalid certificates")
+}
+
+// =============================================================================
+// QR CODE SKI FORMATTING TESTS
+// =============================================================================
+
+func TestFormatSKIForQRCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		ski      string
+		expected string
+	}{
+		{
+			name:     "standard 40 character SKI",
+			ski:      "0357c3d27afc90465d6fcfe212c66c11342c69c3",
+			expected: "0357 c3d2 7afc 9046 5d6f cfe2 12c6 6c11 342c 69c3",
+		},
+		{
+			name:     "empty string",
+			ski:      "",
+			expected: "",
+		},
+		{
+			name:     "length not divisible by four keeps a shorter trailing group",
+			ski:      "0357c3d27",
+			expected: "0357 c3d2 7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatSKIForQRCode(tt.ski))
+		})
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes #113 

Adds spaces every 4 hexadecimal digits to the SKI in both QR code generators, as required by SHIP Spec 1.1.0 §12.7 and covered by test case TC_SPS_QR_001. See the issue for details.

## Changes

- New unexported helper `formatSKIForQRCode()` in `hub/hub_pairing.go`, used by `generateStandardShipQR()` and `generatePairingServiceQR()`
- Existing QR tests updated to the new expected strings, plus a test for the helper

## Note

This changes the output of the public `Hub.GeneratePairingQR()` — consumers comparing the QR string verbatim or parsing `SKI:` up to the first whitespace need to be adjusted.