### PR TITLE
fix(hub): log EINVAL dial failures at debug level

### DIFF
--- a/hub/error_classification.go
+++ b/hub/error_classification.go
@@ -25,8 +25,9 @@ func logConnectionError(err error, context string) {
 		return
 	}
 
-	// Connection refused/timeout can be Debug (expected during discovery)
-	if errors.Is(err, syscall.ECONNREFUSED) {
+	// Connection refused/timeout can be Debug (expected during discovery).
+	// EINVAL: hostname resolved to a zone-less link-local IPv6 address; the hub retries via IP.
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EINVAL) {
 		logging.Log().Debug(context, err)
 		return
 	}

--- a/hub/error_classification_test.go
+++ b/hub/error_classification_test.go
@@ -3,10 +3,11 @@ package hub
 import (
 	"errors"
 	"net"
-	"strings"
+	"os"
 	"syscall"
 	"testing"
 
+	"github.com/enbility/ship-go/logging"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +16,7 @@ func TestLogConnectionError(t *testing.T) {
 		name          string
 		err           error
 		context       string
-		expectedLevel string // "error" or "debug"
+		expectedLevel string // "error", "debug" or "none"
 	}{
 		// Security/Certificate errors should be ERROR level
 		{
@@ -56,6 +57,14 @@ func TestLogConnectionError(t *testing.T) {
 			context:       "connection timeout:",
 			expectedLevel: "debug",
 		},
+		{
+			// .local hostname resolved to a zone-less link-local IPv6 address;
+			// the hub falls back to the advertised IP addresses right after
+			name:          "link-local dial",
+			err:           &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.EINVAL)},
+			context:       "connection to ski at host.local. failed:",
+			expectedLevel: "debug",
+		},
 
 		// Everything else should be ERROR level
 		{
@@ -74,75 +83,28 @@ func TestLogConnectionError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// We can't easily test the actual logging output,
-			// but we can test the classification logic
-			level := classifyErrorLevel(tt.err, tt.context)
-			assert.Equal(t, tt.expectedLevel, level)
+			logger := &levelLogger{level: "none"}
+			logging.SetLogging(logger)
+			defer logging.SetLogging(nil)
+
+			logConnectionError(tt.err, tt.context)
+			assert.Equal(t, tt.expectedLevel, logger.level)
 		})
 	}
 }
 
+// levelLogger records the level logConnectionError emitted at
+type levelLogger struct {
+	logging.NoLogging
+	level string
+}
+
+func (l *levelLogger) Debug(args ...interface{}) { l.level = "debug" }
+func (l *levelLogger) Error(args ...interface{}) { l.level = "error" }
+
 // Helper type for timeout errors
 type timeoutError struct{}
 
-func (e *timeoutError) Error() string { return "timeout" }
-func (e *timeoutError) Timeout() bool { return true }
+func (e *timeoutError) Error() string   { return "timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
 func (e *timeoutError) Temporary() bool { return true }
-
-// Test the classification logic separately
-func TestClassifyErrorLevel(t *testing.T) {
-	// Test direct error classification
-	assert.Equal(t, "none", classifyErrorLevel(nil, ""))
-	assert.Equal(t, "error", classifyErrorLevel(errors.New("test"), ""))
-	
-	// Test context-based classification
-	assert.Equal(t, "error", classifyErrorLevel(errors.New("any"), "certificate"))
-	assert.Equal(t, "error", classifyErrorLevel(errors.New("any"), "SKI validation"))
-	
-	// Test syscall errors
-	assert.Equal(t, "debug", classifyErrorLevel(syscall.ECONNREFUSED, ""))
-	
-	// Test wrapped errors
-	opErr := &net.OpError{
-		Op:  "dial",
-		Net: "tcp",
-		Err: syscall.ECONNREFUSED,
-	}
-	assert.Equal(t, "debug", classifyErrorLevel(opErr, ""))
-}
-
-// Helper function for testing - matches the logic in error_classification.go
-func classifyErrorLevel(err error, context string) string {
-	if err == nil {
-		return "none"
-	}
-	
-	// Security/auth errors should be at Error level
-	if strings.Contains(err.Error(), "certificate") ||
-		strings.Contains(err.Error(), "SKI") ||
-		strings.Contains(context, "certificate") {
-		return "error"
-	}
-	
-	// Check for connection refused
-	if errors.Is(err, syscall.ECONNREFUSED) {
-		return "debug"
-	}
-	
-	// Check for timeout errors
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return "debug"
-	}
-	
-	// Check in wrapped errors
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
-		if errors.Is(opErr.Err, syscall.ECONNREFUSED) {
-			return "debug"
-		}
-	}
-	
-	// Everything else is Error
-	return "error"
-}


### PR DESCRIPTION
Fixes #115.

Dialling an mDNS hostname that resolves to a zone-less link-local IPv6 address fails with `connect: invalid argument` (`EINVAL`). The hub then falls back to the advertised IP addresses and connects, so the hostname attempt is discovery noise like `ECONNREFUSED`, not something to surface as `ERROR`.

Classifies `EINVAL` alongside `ECONNREFUSED` in `logConnectionError`.

The existing table test ran against a test-only copy of the classifier (`classifyErrorLevel`), so it could never catch the implementation drifting. It now drives the real `logConnectionError` through a level-recording logger; the copy and the tests that only exercised the copy are removed. Net -37 lines.

Verified: `go vet ./hub/`, `go test ./hub/` green; with the `dev` version of `error_classification.go` only the new `link-local dial` row fails, all pre-existing rows stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
